### PR TITLE
Contract transaction tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
   preset: 'ts-jest',
-  testRegex: '(/tests/src/.*-tests.ts$)',
-  collectCoverage: true,
+  testRegex: '(/tests/src/.*-tests.ts$)'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "stacks-transactions-js",
-  "version": "0.1.0",
+  "name": "@blockstack/stacks-transactions",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7444,9 +7444,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mississippi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -855,6 +855,11 @@
         "pretty-format": "^25.1.0"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -7190,8 +7195,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start": "webpack-dev-server",
     "build:node": "shx rm -rf lib && tsc --declaration",
     "build:node:watch": "shx rm -rf lib && tsc --watch",
-    "test": "jest"
+    "test": "jest --config ./jest.config.js --coverage"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -63,12 +63,14 @@
   "dependencies": {
     "@types/bn.js": "^4.11.6",
     "@types/elliptic": "^6.4.12",
+    "@types/lodash": "^4.14.149",
     "@types/randombytes": "^2.0.0",
     "@types/ripemd160": "^2.0.0",
     "@types/sha.js": "^2.4.0",
     "bn.js": "^4.11.8",
     "c32check": "^1.0.1",
     "elliptic": "^6.5.2",
+    "lodash": "^4.17.15",
     "randombytes": "^2.1.0",
     "ripemd160": "^2.0.2",
     "sha.js": "^2.4.11"

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -1,3 +1,5 @@
+import * as _ from 'lodash';
+
 import {
   AuthType,
   AddressHashMode,
@@ -114,6 +116,14 @@ export class SpendingCondition extends StacksMessage {
     } else {
       return false;
     }
+  }
+
+  clear(): SpendingCondition {
+    const cleared = _.cloneDeep(this);
+    cleared.nonce = BigInt(0);
+    cleared.feeRate = BigInt(0);
+    cleared.signature = MessageSignature.empty();
+    return cleared;
   }
 
   static makeSigHashPreSign(
@@ -275,8 +285,12 @@ export class Authorization extends StacksMessage {
     this.spendingCondition = spendingConditions;
   }
 
-  intoInitialSighashAuth() {
-
+  intoInitialSighashAuth(): Authorization {
+    if (this.authType === AuthType.Standard) {
+      return new Authorization(AuthType.Standard, this.spendingCondition?.clear())
+    } else {
+      return new Authorization(AuthType.Sponsored, this.spendingCondition?.clear())
+    }
   }
 
   serialize(): Buffer {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,8 +9,8 @@ const MEMO_MAX_LENGTH_BYTES = 34;
 
 enum PayloadType {
   TokenTransfer = "00",
-  ContractCall = "01",
-  SmartContract = "02",
+  SmartContract = "01",
+  ContractCall = "02",
   PoisonMicroblock = "03",
   Coinbase = "04"
 }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,3 +1,5 @@
+import * as _ from 'lodash';
+
 import { 
   DEFAULT_CHAIN_ID,
   TransactionVersion,
@@ -10,7 +12,7 @@ from './constants';
 
 import {
   Authorization,
-  SpendingCondition
+  SpendingCondition,
 } from './authorization';
 
 import {
@@ -19,7 +21,6 @@ import {
   txidFromData,
   sha512_256
 } from './utils';
-
 
 import {
   Payload,
@@ -89,11 +90,12 @@ export class StacksTransaction extends StacksMessage {
   }
 
   signBegin() {
-    if (this.auth === undefined) {
+    let tx = _.cloneDeep(this);
+    if (tx.auth === undefined) {
       throw new Error('"auth" is undefined');
     }
-    this.auth.intoInitialSighashAuth();
-    return this.txid();
+    tx.auth = tx.auth.intoInitialSighashAuth();
+    return tx.txid();
   }
 
   signSingleSigStandard(privateKey: String) {
@@ -195,7 +197,6 @@ export class StacksTransaction extends StacksMessage {
     this.postConditions = LengthPrefixedList.deserialize(bufferReader, PostCondition);
     this.payload = Payload.deserialize(bufferReader);
   }
-
 }
 
 

--- a/tests/src/contracts/kv-store.clar
+++ b/tests/src/contracts/kv-store.clar
@@ -1,0 +1,11 @@
+(define-map store ((key (buff 32))) ((value (buff 32))))
+
+(define-public (get-value (key (buff 32)))
+    (match (map-get? store ((key key)))
+        entry (ok (get value entry))
+        (err 0)))
+
+(define-public (set-value (key (buff 32)) (value (buff 32)))
+    (begin
+        (map-set store ((key key)) ((value value)))
+        (ok 'true)))

--- a/tests/src/index-tests.ts
+++ b/tests/src/index-tests.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+
 import { 
   StacksTransaction,
 } from '../../src/transaction';
@@ -64,7 +66,8 @@ import {
 
 import {
   makeSTXTokenTransfer,
-  makeSmartContractDeploy
+  makeSmartContractDeploy,
+  makeContractCall
 } from '../../src/builders';
 
 import {
@@ -73,8 +76,13 @@ import {
 
 import { 
   TrueCV, 
-  FalseCV 
+  FalseCV, 
+  BufferCV
 } from '../../src/clarity/clarityTypes';
+
+const SECRET_KEY = "e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801";
+const PUBLIC_KEY = "02215340da140268f8a472af9c2b67952fe0a68337665482dae84886adea0945c1";
+const STACKS_ADDRESS = "ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE";
 
 test('Stacks public key and private keys', () => {
   let privKeyString = "edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc";
@@ -449,43 +457,44 @@ test('Make STX token transfer', () => {
 });
 
 test('Make smart contract deploy', () => {
-  let contractName = "contract_name";
-  let codeBody = 
-    "(define-map store ((key (buff 32))) ((value (buff 32))))" +
-    "(define-public (get-value (key (buff 32)))" +
-    "   (match (map-get? store ((key key)))" +
-    "       entry (ok (get value entry))" +
-    "       (err 0)))" +
-    "(define-public (set-value (key (buff 32)) (value (buff 32)))" +
-    "   (begin" +
-    "       (map-set store ((key key)) ((value value)))" +
-    "       (ok 'true)))";
+  let contractName = 'kv-store';
+  let code = fs.readFileSync('./tests/src/contracts/kv-store.clar').toString();
 
   let feeRate = BigInt(0);
   let nonce = BigInt(0);
-  let secretKey = "edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01";
 
-  let transaction = makeSmartContractDeploy(
-    contractName,
-    codeBody,
-    feeRate,
-    nonce,
-    secretKey
-  );
-  
+  let transaction = makeSmartContractDeploy(contractName, code, feeRate, nonce, SECRET_KEY, TransactionVersion.Testnet);
+
   let serialized = transaction.serialize().toString('hex');
 
-  let tx = '0000000000040015c31b8c1c11c515e244b75806bac48d1399c7750000000000000000000000000000' 
-    + '000000017af27712cb2a7754758f3d52479a7c31b7914257c8ac161b8c7883f7f6f8f4f8747ce8ad0949e38' 
-    + 'd8e4981c18d2352184780efe9440459e19f8d7a1ffa465db9030200000000020d636f6e74726163745f6e61' 
-    + '6d650000014528646566696e652d6d61702073746f72652028286b657920286275666620333229292920282' 
-    + '876616c75652028627566662033322929292928646566696e652d7075626c696320286765742d76616c7565' 
-    + '20286b6579202862756666203332292929202020286d6174636820286d61702d6765743f2073746f7265202' 
-    + '8286b6579206b657929292920202020202020656e74727920286f6b20286765742076616c756520656e7472' 
-    + '7929292020202020202028657272203029292928646566696e652d7075626c696320287365742d76616c756' 
-    + '520286b65792028627566662033322929202876616c75652028627566662033322929292020202862656769' 
-    + '6e20202020202020286d61702d7365742073746f72652028286b6579206b6579292920282876616c7565207' 
-    + '6616c756529292920202020202020286f6b202774727565292929'
+  let tx = '80000000000400e6c05355e0c990ffad19a5e9bda394a9c500342900000000000000000000000000000000000073d449aa44ede1bc30c757ccf6cf6119f19567728be8a7d160c188c101e4ad79654f5f2345723c962f5a465ad0e22a4237c456da46194945ae553d366eee9c4b03020000000001086b762d73746f72650000015628646566696e652d6d61702073746f72652028286b657920286275666620333229292920282876616c7565202862756666203332292929290a0a28646566696e652d7075626c696320286765742d76616c756520286b65792028627566662033322929290a20202020286d6174636820286d61702d6765743f2073746f72652028286b6579206b65792929290a2020202020202020656e74727920286f6b20286765742076616c756520656e74727929290a20202020202020202865727220302929290a0a28646566696e652d7075626c696320287365742d76616c756520286b65792028627566662033322929202876616c75652028627566662033322929290a2020202028626567696e0a2020202020202020286d61702d7365742073746f72652028286b6579206b6579292920282876616c75652076616c75652929290a2020202020202020286f6b2027747275652929290a';
+
+  expect(serialized).toBe(tx);
+});
+
+test('Make contract-call', () => {
+  let contractName = 'kv-store';
+  let functionName = 'get-value';
+  let buffer = Buffer.from('foo');
+  let bufferCV = new BufferCV(buffer);
+
+  let feeRate = BigInt(0);
+  let nonce = BigInt(1);
+
+  let transaction = makeContractCall(
+    STACKS_ADDRESS,
+    contractName,
+    functionName,
+    [bufferCV],
+    feeRate,
+    nonce,
+    SECRET_KEY,
+    TransactionVersion.Testnet
+  );
+
+  let serialized = transaction.serialize().toString('hex');
+
+  let tx = '80000000000400e6c05355e0c990ffad19a5e9bda394a9c50034290000000000000001000000000000000000000847ecd645be0141ccbfe7ec25ff9ef1a00cb133623327e351dfb9adb7e09e8f304b0925a3be18f5b1984b2d929f425e5849955abde10f1634501a4e31ba3586030200000000021ae6c05355e0c990ffad19a5e9bda394a9c5003429086b762d73746f7265096765742d76616c7565000000010200000003666f6f';
 
   expect(serialized).toBe(tx);
 });


### PR DESCRIPTION
This PR updates the `contract deploy` test and adds a test for `contract-call` transaction serialization.

It includes a few fixes for `txid` generation which was breaking Transaction signing. It also fixes the values in the `PayloadType` enum, accounting for a typo in SIP 005 which has been fixed (https://github.com/blockstack/stacks-blockchain/pull/1326)

Additionally, I moved the `collectCoverage` option out of the Jest config and into `package.json`, as it was breaking my VSCode debugger (https://github.com/kulshekhar/ts-jest/issues/484)