### PR TITLE
refactor: use bn.js instead of BigInt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This library supports the creation of the following Stacks 2.0 transaction types
 
 ## Key Generation
 ```javascript
-const { StacksPrivateKey } = require('stacks-transactions-js');
+const { StacksPrivateKey } = require('stacks-transactions');
 
 // Random key
 var privateKey = StacksPrivateKey.makeRandom();
@@ -30,12 +30,13 @@ var privateKey = new StacksPrivateKey(key);
 
 ## STX Token Transfer Transaction
 ```javascript
-const { makeSTXTokenTransfer } = require('stacks-transactions-js');
+const { makeSTXTokenTransfer } = require('stacks-transactions');
+const BigNum = require('bn.js');
 
 var recipientAddress = 'SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159';
-var amount = BigInt(12345);
-var feeRate = BigInt(0);
-var nonce = BigInt(0);
+var amount = new BigNum(12345);
+var feeRate = new BigNum(0);
+var nonce = new BigNum(0);
 var secretKey = "edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01";
 var memo = "test memo";
 
@@ -55,14 +56,15 @@ var serializedTx = transaction.serialize().toString('hex');
 
 ## Smart Contract Deploy Transaction
 ```javascript
-const { makeSmartContractDeploy } = require('stacks-transactions-js');
+const { makeSmartContractDeploy } = require('stacks-transactions');
+const BigNum = require('bn.js');
 
 var contractName = 'contract_name';
 var code = fs.readFileSync('/path/to/contract.clar').toString();
 var secretKey = "edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01";
 
-var feeRate = BigInt(0);
-var nonce = BigInt(0);
+var feeRate = new BigNum(0);
+var nonce = new BigNum(0);
 
 var transaction = makeSmartContractDeploy(contractName, code, feeRate, nonce, secretKey, TransactionVersion.Mainnet);
 
@@ -73,7 +75,8 @@ var serializedTx = transaction.serialize().toString('hex');
 ## Smart Contract Function Call
 
 ```javascript
-const { makeContractCall, BufferCV } = require('stacks-transactions-js');
+const { makeContractCall, BufferCV } = require('stacks-transactions');
+const BigNum = require('bn.js');
 
 var contractAddress = 'SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X';
 var contractName = 'contract_name';
@@ -83,8 +86,8 @@ var bufferClarityValue = new BufferCV(buffer);
 var functionArgs = [bufferClarityValue];
 var secretKey = "edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01";
 
-var feeRate = BigInt(0);
-var nonce = BigInt(0);
+var feeRate = new BigNum(0);
+var nonce = new BigNum(0);
 
 var transaction = makeContractCall(
   contractAddress,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "stacks-transactions-js",
-  "version": "0.1.0",
+  "name": "@blockstack/stacks-transactions",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4074,8 +4074,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4096,14 +4095,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4118,20 +4115,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4248,8 +4242,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4261,7 +4254,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4276,7 +4268,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4284,14 +4275,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4310,7 +4299,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4400,8 +4388,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4413,7 +4400,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4499,8 +4485,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4536,7 +4521,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4556,7 +4540,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4600,14 +4583,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -27,6 +27,8 @@ import {
   StacksMessage
 } from './message'
 
+import * as BigNum from 'bn.js';
+
 export class SpendingAuthorizationField {
   fieldID?: Buffer;
   body?: Buffer;
@@ -75,8 +77,8 @@ export class MessageSignature extends StacksMessage {
 export class SpendingCondition extends StacksMessage {
   addressHashMode?: AddressHashMode;
   signerAddress?: Address;
-  nonce?: BigInt;
-  feeRate?: BigInt;
+  nonce?: BigNum;
+  feeRate?: BigNum;
   pubKeyEncoding?: PubKeyEncoding;
   signature: MessageSignature;
   signaturesRequired?: number;
@@ -84,8 +86,8 @@ export class SpendingCondition extends StacksMessage {
   constructor(
     addressHashMode?: AddressHashMode, 
     pubKey?: string, 
-    nonce?: BigInt, 
-    feeRate?: BigInt
+    nonce?: BigNum, 
+    feeRate?: BigNum
   ) {
     super();
     this.addressHashMode = addressHashMode;
@@ -119,8 +121,8 @@ export class SpendingCondition extends StacksMessage {
   static makeSigHashPreSign(
     curSigHash: string, 
     authType: AuthType, 
-    feeRate: BigInt, 
-    nonce: BigInt
+    feeRate: BigNum, 
+    nonce: BigNum
   ): string {
     // new hash combines the previous hash and all the new data this signature will add. This
     // includes:
@@ -130,7 +132,8 @@ export class SpendingCondition extends StacksMessage {
     // * nonce (big-endian 8-byte number)
     let hashLength = 32 + 1 + 8 + 8;
 
-    let sigHash = curSigHash + authType + bigIntToHexString(feeRate, 8) + bigIntToHexString(nonce, 8);
+    let sigHash = curSigHash + authType + feeRate.toBuffer('be', 8).toString('hex') 
+      + nonce.toBuffer('be', 8).toString('hex');
 
     if (Buffer.from(sigHash, 'hex').byteLength > hashLength) {
       throw Error('Invalid signature hash length');
@@ -163,8 +166,8 @@ export class SpendingCondition extends StacksMessage {
   static nextSignature(
     curSigHash: string, 
     authType: AuthType, 
-    feeRate: BigInt, 
-    nonce: BigInt, 
+    feeRate: BigNum, 
+    nonce: BigNum, 
     privateKey: StacksPrivateKey
   ): {
     nextSig: MessageSignature, 
@@ -205,8 +208,8 @@ export class SpendingCondition extends StacksMessage {
     }
     bufferArray.appendHexString(this.addressHashMode);
     bufferArray.appendHexString(this.signerAddress.data);
-    bufferArray.appendHexString(bigIntToHexString(this.nonce));
-    bufferArray.appendHexString(bigIntToHexString(this.feeRate));
+    bufferArray.push(this.nonce.toBuffer('be', 8));
+    bufferArray.push(this.feeRate.toBuffer('be', 8));
 
     if (this.addressHashMode === AddressHashMode.SerializeP2PKH ||
       this.addressHashMode === AddressHashMode.SerializeP2WPKH)
@@ -229,8 +232,8 @@ export class SpendingCondition extends StacksMessage {
     this.addressHashMode = bufferReader.read(1).toString('hex') as AddressHashMode;
     let signerPubKeyHash = bufferReader.read(20).toString('hex');
     this.signerAddress = Address.fromData(0, signerPubKeyHash);
-    this.nonce = hexStringToBigInt(bufferReader.read(8).toString('hex'));
-    this.feeRate = hexStringToBigInt(bufferReader.read(8).toString('hex'));
+    this.nonce = new BigNum(bufferReader.read(8).toString('hex'), 16);
+    this.feeRate = new BigNum(bufferReader.read(8).toString('hex'), 16);
 
     if (this.addressHashMode === AddressHashMode.SerializeP2PKH ||
       this.addressHashMode === AddressHashMode.SerializeP2WPKH)
@@ -249,8 +252,8 @@ export class SingleSigSpendingCondition extends SpendingCondition {
   constructor(
     addressHashMode?: AddressHashMode, 
     pubKey?: string, 
-    nonce?: BigInt, 
-    feeRate?: BigInt
+    nonce?: BigNum, 
+    feeRate?: BigNum
   ) {
     super(addressHashMode, pubKey, nonce, feeRate);
     this.signaturesRequired = 1;

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -30,15 +30,17 @@ import {
   ClarityValue
 } from './clarity/clarityTypes';
 
+import * as BigNum from 'bn.js';
+
 /** 
  * Generates a Stacks token transfer transaction
  *
  * Returns a signed Stacks token transfer transaction.
  * 
  * @param  {String} recipientAddress - the c32check address of the recipient
- * @param  {BigInt} amount - number of tokens to transfer in microstacks
- * @param  {BigInt} feeRate - transaction fee rate in microstacks
- * @param  {BigInt} nonce - a nonce must be increased monotonically with each new transaction
+ * @param  {BigNum} amount - number of tokens to transfer in microstacks
+ * @param  {BigNum} feeRate - transaction fee rate in microstacks
+ * @param  {BigNum} nonce - a nonce must be increased monotonically with each new transaction
  * @param  {String} senderKey - hex string sender private key used to sign transaction
  * @param  {TransactionVersion} version - can be set to mainnet or testnet
  * @param  {String} memo - an arbitrary string to include with the transaction, must be less than
@@ -48,9 +50,9 @@ import {
  */
 export function makeSTXTokenTransfer(
   recipientAddress: string,
-  amount: BigInt,
-  feeRate: BigInt,
-  nonce: BigInt,
+  amount: BigNum,
+  feeRate: BigNum,
+  nonce: BigNum,
   senderKey: string,
   version: TransactionVersion = TransactionVersion.Mainnet,
   memo?: string,
@@ -91,8 +93,8 @@ export function makeSTXTokenTransfer(
  * 
  * @param  {String} contractName - the contract name
  * @param  {String} codeBody - the code body string
- * @param  {BigInt} feeRate - transaction fee rate in microstacks
- * @param  {BigInt} nonce - a nonce must be increased monotonically with each new transaction
+ * @param  {BigNum} feeRate - transaction fee rate in microstacks
+ * @param  {BigNum} nonce - a nonce must be increased monotonically with each new transaction
  * @param  {String} senderKey - hex string sender private key used to sign transaction
  * @param  {TransactionVersion} version - can be set to mainnet or testnet
  *
@@ -101,8 +103,8 @@ export function makeSTXTokenTransfer(
 export function makeSmartContractDeploy(
   contractName: string,
   codeBody: string,
-  feeRate: BigInt,
-  nonce: BigInt,
+  feeRate: BigNum,
+  nonce: BigNum,
   senderKey: string,
   version: TransactionVersion = TransactionVersion.Mainnet
 ): StacksTransaction {
@@ -143,8 +145,8 @@ export function makeSmartContractDeploy(
  * @param  {String} contractName - the contract name
  * @param  {String} functionName - name of the function to be called
  * @param  {[ClarityValue]} functionArgs - an array of Clarity values as arguments to the function call
- * @param  {BigInt} feeRate - transaction fee rate in microstacks
- * @param  {BigInt} nonce - a nonce must be increased monotonically with each new transaction
+ * @param  {BigNum} feeRate - transaction fee rate in microstacks
+ * @param  {BigNum} nonce - a nonce must be increased monotonically with each new transaction
  * @param  {String} senderKey - hex string sender private key used to sign transaction
  * @param  {TransactionVersion} version - can be set to mainnet or testnet
  *
@@ -155,8 +157,8 @@ export function makeContractCall(
   contractName: string, 
   functionName: string, 
   functionArgs: ClarityValue[],
-  feeRate: BigInt,
-  nonce: BigInt,
+  feeRate: BigNum,
+  nonce: BigNum,
   senderKey: string,
   version: TransactionVersion = TransactionVersion.Mainnet
 ): StacksTransaction {

--- a/src/clarity/clarityTypes.ts
+++ b/src/clarity/clarityTypes.ts
@@ -1,4 +1,4 @@
-import * as BN from 'bn.js';
+import * as BigNum from 'bn.js';
 import { LengthPrefixedString, Address } from '../types';
 import { CLARITY_INT_SIZE, ClarityType } from '../constants';
 import { BufferReader, BufferArray } from '../utils';
@@ -136,12 +136,12 @@ class BufferCV extends ClarityValue {
 
 class IntCV extends ClarityValue {
   readonly type = ClarityType.Int;
-  readonly value: BN;
+  readonly value: BigNum;
 
   constructor(value: number | string | Buffer) {
     super();
 
-    const bn = new BN(value);
+    const bn = new BigNum(value);
     this.value = bn.toTwos(CLARITY_INT_SIZE);
 
     if (this.value.bitLength() > CLARITY_INT_SIZE) {
@@ -159,11 +159,11 @@ const intCV = (val: number | string | Buffer) => new IntCV(val);
 
 class UIntCV extends ClarityValue {
   readonly type = ClarityType.UInt;
-  readonly value: BN;
+  readonly value: BigNum;
 
   constructor(value: number | string | Buffer) {
     super();
-    const bn = new BN(value);
+    const bn = new BigNum(value);
     this.value = bn.toTwos(CLARITY_INT_SIZE);
 
     if (this.value.isNeg()) {

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -23,7 +23,10 @@ import {
 import {
   StacksMessage,
 } from './message'
+
 import { ClarityValue } from './clarity/clarityTypes';
+
+import * as BigNum from 'bn.js';
 
 export class Payload extends StacksMessage {
   payloadType?: PayloadType;
@@ -32,7 +35,7 @@ export class Payload extends StacksMessage {
   assetInfo?: AssetInfo;
   assetName?: LengthPrefixedString;
   recipientAddress?: Address;
-  amount?: BigInt;
+  amount?: BigNum;
   memo?: MemoString;
 
   contractAddress?: Address;
@@ -61,7 +64,7 @@ export class Payload extends StacksMessage {
         if (this.amount === undefined) {
           throw new Error('"amount" is undefined');
         }
-        bufferArray.appendHexString(bigIntToHexString(this.amount));
+        bufferArray.push(this.amount.toBuffer('be', 8));
         if (this.memo === undefined) {
           throw new Error('"memo" is undefined');
         }
@@ -124,8 +127,7 @@ export class Payload extends StacksMessage {
     switch (this.payloadType) {
       case PayloadType.TokenTransfer:
         this.recipientAddress = Address.deserialize(bufferReader);
-        let amount = bufferReader.read(8).toString('hex');
-        this.amount = hexStringToBigInt(amount);
+        this.amount = new BigNum(bufferReader.read(8).toString('hex'), 16);
         this.memo = LengthPrefixedString.deserialize(bufferReader);
         break;
       case PayloadType.ContractCall:
@@ -158,7 +160,7 @@ export class Payload extends StacksMessage {
 export class TokenTransferPayload extends Payload {
   constructor(
     recipientAddress?: string, 
-    amount?: BigInt, 
+    amount?: BigNum, 
     memo?: string
   ) {
     super();

--- a/src/postcondition.ts
+++ b/src/postcondition.ts
@@ -22,19 +22,21 @@ import {
   StacksMessage
 } from './message';
 
+import * as BigNum from 'bn.js';
+
 export class PostCondition extends StacksMessage {
   postConditionType?: PostConditionType;
   principal?: Principal;
   conditionCode?: FungibleConditionCode | NonFungibleConditionCode;
   assetInfo?: AssetInfo;
   assetName?: LengthPrefixedString;
-  amount?: BigInt;
+  amount?: BigNum;
 
   constructor(
     postConditionType?: PostConditionType, 
     principal?: Principal, 
     conditionCode?: FungibleConditionCode | NonFungibleConditionCode,
-    amount?: BigInt,
+    amount?: BigNum,
     assetInfo?: AssetInfo,
     assetName?: string
   ) {
@@ -85,7 +87,7 @@ export class PostCondition extends StacksMessage {
       if (this.amount === undefined) {
         throw new Error('"amount" is undefined');
       }
-      bufferArray.appendHexString(bigIntToHexString(this.amount));
+      bufferArray.push(this.amount.toBuffer('be', 8));
     }
 
     return bufferArray.concatBuffer();
@@ -111,7 +113,7 @@ export class PostCondition extends StacksMessage {
     if (this.postConditionType === PostConditionType.STX 
       || this.postConditionType === PostConditionType.Fungible
     ) {
-      this.amount = hexStringToBigInt(bufferReader.read(8).toString('hex'));
+      this.amount = new BigNum(bufferReader.read(8).toString('hex'), 16);
     }
   }
 }
@@ -120,7 +122,7 @@ export class STXPostCondition extends PostCondition {
   constructor(
     principal?: Principal, 
     conditionCode?: FungibleConditionCode,
-    amount?: BigInt
+    amount?: BigNum
   ) {
     super(
       PostConditionType.STX, 
@@ -135,7 +137,7 @@ export class FungiblePostCondition extends PostCondition {
   constructor(
     principal?: Principal, 
     conditionCode?: FungibleConditionCode,
-    amount?: BigInt,
+    amount?: BigNum,
     assetInfo?: AssetInfo
   ) {
     super(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,10 +51,10 @@ export const leftPadHexToLength = (hexString: string, length: number): string =>
 export const rightPadHexToLength = (hexString: string, length: number): string => 
   hexString.padEnd(length, '0');
 
-export const bigIntToHexString = (integer: BigInt, lengthBytes: number = 8): string => 
-  integer.toString(16).padStart(lengthBytes * 2, '0');
+// export const bigIntToHexString = (integer: BigInt, lengthBytes: number = 8): string => 
+//   integer.toString(16).padStart(lengthBytes * 2, '0');
 
-export const hexStringToBigInt = (hexString: string): BigInt => BigInt("0x" + hexString);
+// export const hexStringToBigInt = (hexString: string): BigInt => BigInt("0x" + hexString);
 
 export const intToHexString = (integer: number, lengthBytes: number = 8): string => 
   integer.toString(16).padStart(lengthBytes * 2, '0');

--- a/tests/src/index-tests.ts
+++ b/tests/src/index-tests.ts
@@ -76,6 +76,8 @@ import {
   FalseCV 
 } from '../../src/clarity/clarityTypes';
 
+import * as BigNum from 'bn.js';
+
 test('Stacks public key and private keys', () => {
   let privKeyString = "edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc";
   let pubKeyString = "04ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab" 
@@ -160,7 +162,7 @@ test('Asset info serialization and deserialization', () => {
 
 test('STX token transfer payload serialization and deserialization', () => {
   let recipientAddress = "SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159";
-  let amount = BigInt(2500000);
+  let amount = new BigNum(2500000);
 
   let payload = new TokenTransferPayload(
     recipientAddress, 
@@ -171,7 +173,7 @@ test('STX token transfer payload serialization and deserialization', () => {
   let deserialized = serializeDeserialize(payload, TokenTransferPayload);
   expect(deserialized.payloadType).toBe(payload.payloadType);
   expect(deserialized.recipientAddress!.toString()).toBe(recipientAddress);
-  expect(deserialized.amount).toBe(amount);
+  expect(deserialized.amount!.toNumber()).toBe(amount.toNumber());
 });
 
 test('Contract call payload serialization and deserialization', () => {
@@ -261,7 +263,7 @@ test('STX post condition serialization and deserialization', () => {
   );
   
   let conditionCode = FungibleConditionCode.GreaterEqual;
-  let amount = BigInt(1000000);
+  let amount = new BigNum(1000000);
 
   let postCondition = new STXPostCondition(
     standardPrincipal, 
@@ -274,7 +276,7 @@ test('STX post condition serialization and deserialization', () => {
   expect(deserialized.principal!.principalType).toBe(standardPrincipalType);
   expect(deserialized.principal!.address.toString()).toBe(address);
   expect(deserialized.conditionCode).toBe(conditionCode);
-  expect(deserialized.amount).toBe(amount);
+  expect(deserialized.amount!.toNumber()).toBe(amount.toNumber());
 });
 
 test('Fungible post condition serialization and deserialization', () => {
@@ -285,7 +287,7 @@ test('Fungible post condition serialization and deserialization', () => {
   let standardPrincipal = new StandardPrincipal(address);
   
   let conditionCode = FungibleConditionCode.GreaterEqual;
-  let amount = BigInt(1000000);
+  let amount = new BigNum(1000000);
 
   let assetAddress = "SP2ZP4GJDZJ1FDHTQ963F0292PE9J9752TZJ68F21";
   let assetContractName = "contract_name";
@@ -304,7 +306,7 @@ test('Fungible post condition serialization and deserialization', () => {
   expect(deserialized.principal!.principalType).toBe(standardPrincipalType);
   expect(deserialized.principal!.address.toString()).toBe(address);
   expect(deserialized.conditionCode).toBe(conditionCode);
-  expect(deserialized.amount).toBe(amount);
+  expect(deserialized.amount!.toNumber()).toBe(amount.toNumber());
   expect(deserialized.assetInfo!.address.toString()).toBe(assetAddress);
   expect(deserialized.assetInfo!.contractName.toString()).toBe(assetContractName);
   expect(deserialized.assetInfo!.assetName.toString()).toBe(assetName);
@@ -352,8 +354,8 @@ test('Non-fungible post condition serialization and deserialization', () => {
 
 test('Single spending condition serialization and deserialization', () => {
   let addressHashMode = AddressHashMode.SerializeP2PKH;
-  let nonce = BigInt(0);
-  let feeRate = BigInt(0);
+  let nonce = new BigNum(0);
+  let feeRate = new BigNum(0);
   let pubKey = "03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab";
   let secretKey = "edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01";
   let spendingCondition = new SingleSigSpendingCondition(addressHashMode, pubKey, nonce, feeRate);
@@ -361,8 +363,8 @@ test('Single spending condition serialization and deserialization', () => {
 
   let deserialized = serializeDeserialize(spendingCondition, SingleSigSpendingCondition);
   expect(deserialized.addressHashMode).toBe(addressHashMode);
-  expect(deserialized.nonce).toBe(nonce);
-  expect(deserialized.feeRate).toBe(feeRate);
+  expect(deserialized.nonce!.toNumber()).toBe(nonce.toNumber());
+  expect(deserialized.feeRate!.toNumber()).toBe(feeRate.toNumber());
   expect(deserialized.signature.toString()).toBe(emptySignature.toString());
 });
 
@@ -375,7 +377,7 @@ test('STX token transfer transaction serialization and deserialization', () => {
   let postConditionMode = PostConditionMode.Deny;
 
   let recipientAddress = "SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159";
-  let amount = BigInt(2500000);
+  let amount = new BigNum(2500000);
   let memo = "memo (not included";
 
   let payload = new TokenTransferPayload(
@@ -385,8 +387,8 @@ test('STX token transfer transaction serialization and deserialization', () => {
   )
 
   let addressHashMode = AddressHashMode.SerializeP2PKH;
-  let nonce = BigInt(0);
-  let feeRate = BigInt(0);
+  let nonce = new BigNum(0);
+  let feeRate = new BigNum(0);
   let pubKey = "03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab";
   let pubKeyHash = hash_p2pkh(pubKey);
   let secretKey = "edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01";
@@ -410,20 +412,20 @@ test('STX token transfer transaction serialization and deserialization', () => {
   expect(deserialized.chainId).toBe(chainId);
   expect(deserialized.auth!.authType).toBe(authType);
   expect(deserialized.auth!.spendingCondition!.addressHashMode).toBe(addressHashMode);
-  expect(deserialized.auth!.spendingCondition!.nonce).toBe(nonce);
-  expect(deserialized.auth!.spendingCondition!.feeRate).toBe(feeRate);
+  expect(deserialized.auth!.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
+  expect(deserialized.auth!.spendingCondition!.feeRate!.toNumber()).toBe(feeRate.toNumber());
   expect(deserialized.anchorMode).toBe(anchorMode);
   expect(deserialized.postConditionMode).toBe(postConditionMode);
   expect(deserialized.postConditions.length).toBe(0);
   expect(deserialized.payload!.recipientAddress!.toString()).toBe(recipientAddress);
-  expect(deserialized.payload!.amount).toBe(amount);
+  expect(deserialized.payload!.amount!.toNumber()).toBe(amount.toNumber());
 });
 
 test('Make STX token transfer', () => {
   let recipientAddress = 'SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159';
-  let amount = BigInt(12345);
-  let feeRate = BigInt(0);
-  let nonce = BigInt(0);
+  let amount = new BigNum(12345);
+  let feeRate = new BigNum(0);
+  let nonce = new BigNum(0);
   let secretKey = "edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01";
   let memo = "test memo";
 
@@ -461,8 +463,8 @@ test('Make smart contract deploy', () => {
     "       (map-set store ((key key)) ((value value)))" +
     "       (ok 'true)))";
 
-  let feeRate = BigInt(0);
-  let nonce = BigInt(0);
+  let feeRate = new BigNum(0);
+  let nonce = new BigNum(0);
   let secretKey = "edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01";
 
   let transaction = makeSmartContractDeploy(


### PR DESCRIPTION
This PR switches from BigInt to bn.js throughout to improve compatibility. 