### PR TITLE
fix: use toArrayLike instead of toBuffer

### DIFF
--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -140,8 +140,8 @@ export class SpendingCondition extends StacksMessage {
     // * nonce (big-endian 8-byte number)
     let hashLength = 32 + 1 + 8 + 8;
 
-    let sigHash = curSigHash + authType + feeRate.toBuffer('be', 8).toString('hex') 
-      + nonce.toBuffer('be', 8).toString('hex');
+    let sigHash = curSigHash + authType + feeRate.toArrayLike(Buffer, 'be', 8).toString('hex') 
+      + nonce.toArrayLike(Buffer, 'be', 8).toString('hex');
 
     if (Buffer.from(sigHash, 'hex').byteLength > hashLength) {
       throw Error('Invalid signature hash length');
@@ -216,8 +216,8 @@ export class SpendingCondition extends StacksMessage {
     }
     bufferArray.appendHexString(this.addressHashMode);
     bufferArray.appendHexString(this.signerAddress.data);
-    bufferArray.push(this.nonce.toBuffer('be', 8));
-    bufferArray.push(this.feeRate.toBuffer('be', 8));
+    bufferArray.push(this.nonce.toArrayLike(Buffer, 'be', 8));
+    bufferArray.push(this.feeRate.toArrayLike(Buffer, 'be', 8));
 
     if (this.addressHashMode === AddressHashMode.SerializeP2PKH ||
       this.addressHashMode === AddressHashMode.SerializeP2WPKH)

--- a/src/clarity/clarityTypes.ts
+++ b/src/clarity/clarityTypes.ts
@@ -150,7 +150,7 @@ class IntCV extends ClarityValue {
   }
 
   serialize() {
-    const buffer = this.value.toBuffer('be', 16);
+    const buffer = this.value.toArrayLike(Buffer, 'be', 16);
     return prefixTypeID(this.type, buffer);
   }
 }
@@ -174,7 +174,7 @@ class UIntCV extends ClarityValue {
   }
 
   serialize() {
-    const buffer = this.value.toBuffer('be', 16);
+    const buffer = this.value.toArrayLike(Buffer, 'be', 16);
     return prefixTypeID(this.type, buffer);
   }
 }

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -62,7 +62,7 @@ export class Payload extends StacksMessage {
         if (this.amount === undefined) {
           throw new Error('"amount" is undefined');
         }
-        bufferArray.push(this.amount.toBuffer('be', 8));
+        bufferArray.push(this.amount.toArrayLike(Buffer, 'be', 8));
         if (this.memo === undefined) {
           throw new Error('"memo" is undefined');
         }

--- a/src/postcondition.ts
+++ b/src/postcondition.ts
@@ -85,7 +85,7 @@ export class PostCondition extends StacksMessage {
       if (this.amount === undefined) {
         throw new Error('"amount" is undefined');
       }
-      bufferArray.push(this.amount.toBuffer('be', 8));
+      bufferArray.push(this.amount.toArrayLike(Buffer, 'be', 8));
     }
 
     return bufferArray.concatBuffer();


### PR DESCRIPTION
The way `bn.js` implements `toBuffer` is problematic for web environments. It tries to `require('buffer')`, which doesn't play well in web environments. However, it's easy to add a global `Buffer` as a polyfill. When using a global polyfill, we need to use `toArrayLike(Buffer, ...)` instead of `toBuffer`. This will work much better in web environments.

Note: These changes do not include the ESLint setup from #27. We should merge that first, and then fix any merge this PR.