### PR TITLE
feat: add support for specifying post-condition mode

### DIFF
--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -225,6 +225,7 @@ export class SpendingCondition extends StacksMessage {
       this.addressHashMode === AddressHashMode.SerializeP2WSH
     ) {
       // TODO
+      throw new Error(`Not yet implemented: serializing AddressHashMode: ${this.addressHashMode}`);
     }
 
     return bufferArray.concatBuffer();
@@ -307,7 +308,9 @@ export class Authorization extends StacksMessage {
         break;
       case AuthType.Sponsored:
         // TODO
-        break;
+        throw new Error('Not yet implemented: serializing sponsored transactions');
+      default:
+        throw new Error(`Unexpected transaction AuthType while serializing: ${this.authType}`);
     }
 
     return bufferArray.concatBuffer();
@@ -322,7 +325,9 @@ export class Authorization extends StacksMessage {
         break;
       case AuthType.Sponsored:
         // TODO
-        break;
+        throw new Error('Not yet implemented: deserializing sponsored transactions');
+      default:
+        throw new Error(`Unexpected transaction AuthType while deserializing: ${this.authType}`);
     }
   }
 }

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -20,6 +20,7 @@ import {
   AddressHashMode,
   FungibleConditionCode,
   NonFungibleConditionCode,
+  PostConditionMode,
 } from './constants';
 
 import { StandardPrincipal, ContractPrincipal, AssetInfo } from './types';
@@ -44,6 +45,7 @@ export interface TokenTransferOptions {
   nonce?: BigNum;
   version?: TransactionVersion;
   memo?: string;
+  postConditionMode?: PostConditionMode;
   postConditions?: PostCondition[];
 }
 
@@ -71,6 +73,7 @@ export function makeSTXTokenTransfer(
     nonce: new BigNum(0),
     version: TransactionVersion.Mainnet,
     memo: '',
+    postConditionMode: PostConditionMode.Deny,
   };
 
   const normalizedOptions = Object.assign(defaultOptions, options);
@@ -89,6 +92,7 @@ export function makeSTXTokenTransfer(
   const authorization = new StandardAuthorization(spendingCondition);
 
   const transaction = new StacksTransaction(normalizedOptions.version, authorization, payload);
+  transaction.postConditionMode = normalizedOptions.postConditionMode;
 
   if (normalizedOptions.postConditions && normalizedOptions.postConditions.length > 0) {
     normalizedOptions.postConditions.forEach(postCondition => {
@@ -115,6 +119,7 @@ export function makeSTXTokenTransfer(
 export interface ContractDeployOptions {
   nonce?: BigNum;
   version?: TransactionVersion;
+  postConditionMode?: PostConditionMode;
   postConditions?: PostCondition[];
 }
 
@@ -140,6 +145,7 @@ export function makeSmartContractDeploy(
   const defaultOptions = {
     nonce: new BigNum(0),
     version: TransactionVersion.Mainnet,
+    postConditionMode: PostConditionMode.Deny,
   };
 
   const normalizedOptions = Object.assign(defaultOptions, options);
@@ -158,6 +164,7 @@ export function makeSmartContractDeploy(
   const authorization = new StandardAuthorization(spendingCondition);
 
   const transaction = new StacksTransaction(normalizedOptions.version, authorization, payload);
+  transaction.postConditionMode = normalizedOptions.postConditionMode;
 
   if (normalizedOptions.postConditions && normalizedOptions.postConditions.length > 0) {
     normalizedOptions.postConditions.forEach(postCondition => {
@@ -184,6 +191,7 @@ export function makeSmartContractDeploy(
 export interface ContractCallOptions {
   nonce?: BigNum;
   version?: TransactionVersion;
+  postConditionMode?: PostConditionMode;
   postConditions?: PostCondition[];
 }
 
@@ -215,6 +223,7 @@ export function makeContractCall(
   const defaultOptions = {
     nonce: new BigNum(0),
     version: TransactionVersion.Mainnet,
+    postConditionMode: PostConditionMode.Deny,
   };
 
   const normalizedOptions = Object.assign(defaultOptions, options);
@@ -238,6 +247,7 @@ export function makeContractCall(
   const authorization = new StandardAuthorization(spendingCondition);
 
   const transaction = new StacksTransaction(normalizedOptions.version, authorization, payload);
+  transaction.postConditionMode = normalizedOptions.postConditionMode;
 
   if (normalizedOptions.postConditions && normalizedOptions.postConditions.length > 0) {
     normalizedOptions.postConditions.forEach(postCondition => {

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -77,7 +77,9 @@ export class StacksPrivateKey {
     } else if (key.length === 64) {
       this.compressed = false;
     } else {
-      throw new Error('Improperly formatted private-key hex string: length should be 64 or 66.');
+      throw new Error(
+        `Improperly formatted private-key hex string: length should be 64 or 66, provided with length ${key.length}`
+      );
     }
 
     this.data = Buffer.from(key, 'hex');
@@ -87,7 +89,7 @@ export class StacksPrivateKey {
     const ec = new EC('secp256k1');
     const options = { entropy: randomBytes(32) };
     const keyPair = ec.genKeyPair(options);
-    const privateKey = keyPair.getPrivate().toString('hex');
+    const privateKey = keyPair.getPrivate().toString('hex', 32);
     return new StacksPrivateKey(privateKey);
   }
 

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -98,7 +98,9 @@ export class Payload extends StacksMessage {
         bufferArray.push(this.coinbaseBuffer);
         break;
       default:
-        break;
+        throw new Error(
+          `Unexpected transaction payload type while serializing: ${this.payloadType}`
+        );
     }
 
     return bufferArray.concatBuffer();
@@ -134,7 +136,9 @@ export class Payload extends StacksMessage {
         this.coinbaseBuffer = bufferReader.read(COINBASE_BUFFER_LENGTH_BYTES);
         break;
       default:
-        break;
+        throw new Error(
+          `Unexpected transaction payload type while deserializing: ${this.payloadType}`
+        );
     }
   }
 }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -64,17 +64,19 @@ export class StacksTransaction extends StacksMessage {
 
     if (payload !== undefined) {
       switch (payload.payloadType) {
-        case PayloadType.Coinbase: {
-          this.anchorMode = AnchorMode.OnChainOnly;
-          break;
-        }
+        case PayloadType.Coinbase:
         case PayloadType.PoisonMicroblock: {
           this.anchorMode = AnchorMode.OnChainOnly;
           break;
         }
-        default: {
+        case PayloadType.ContractCall:
+        case PayloadType.SmartContract:
+        case PayloadType.TokenTransfer: {
           this.anchorMode = AnchorMode.Any;
           break;
+        }
+        default: {
+          throw new Error(`Unexpected transaction payload type: ${payload.payloadType}`);
         }
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,7 +120,10 @@ export class Address extends StacksMessage {
       case AddressHashMode.SerializeP2PKH:
         return Address.fromData(version, hash_p2pkh(publicKeys[0].toString()));
       default:
-        return new Address('');
+        // TODO
+        throw new Error(
+          `Not yet implemented: address construction using public keys for hash mode: ${hashMode}`
+        );
     }
   }
 

--- a/tests/src/builder-tests.ts
+++ b/tests/src/builder-tests.ts
@@ -18,6 +18,7 @@ import {
   TransactionVersion,
   FungibleConditionCode,
   NonFungibleConditionCode,
+  PostConditionMode,
 } from '../../src/constants';
 
 import { bufferCV } from '../../src/clarity';
@@ -207,6 +208,7 @@ test('Make contract-call with post conditions', () => {
     nonce: new BigNum(1),
     version: TransactionVersion.Testnet,
     postConditions,
+    postConditMode: PostConditionMode.Deny,
   };
 
   const transaction = makeContractCall(
@@ -237,6 +239,42 @@ test('Make contract-call with post conditions', () => {
     '8499e65f69c7798fd5d113746573742d61737365742d636f6e74726163740f746573742d61737365742d6e' +
     '616d6510746f6b656e2d61737365742d6e616d6510021ae6c05355e0c990ffad19a5e9bda394a9c5003429' +
     '086b762d73746f7265096765742d76616c7565000000010200000003666f6f';
+
+  expect(serialized).toBe(tx);
+});
+
+test('Make contract-call with post condition allow mode', () => {
+  const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'kv-store';
+  const functionName = 'get-value';
+  const buffer = bufferCV(Buffer.from('foo'));
+  const secretKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
+
+  const feeRate = new BigNum(0);
+
+  const options = {
+    nonce: new BigNum(1),
+    version: TransactionVersion.Testnet,
+    postConditMode: PostConditionMode.Allow,
+  };
+
+  const transaction = makeContractCall(
+    contractAddress,
+    contractName,
+    functionName,
+    [buffer],
+    feeRate,
+    secretKey,
+    options
+  );
+
+  const serialized = transaction.serialize().toString('hex');
+
+  const tx =
+    '80000000000400e6c05355e0c990ffad19a5e9bda394a9c500342900000000000000010000000000000000' +
+    '00000847ecd645be0141ccbfe7ec25ff9ef1a00cb133623327e351dfb9adb7e09e8f304b0925a3be18f5b1' +
+    '984b2d929f425e5849955abde10f1634501a4e31ba3586030200000000021ae6c05355e0c990ffad19a5e9' +
+    'bda394a9c5003429086b762d73746f7265096765742d76616c7565000000010200000003666f6f';
 
   expect(serialized).toBe(tx);
 });


### PR DESCRIPTION
Use the following template to create your pull request

## Description

Make specifying post-condition fields in tx builders consistent. Example of new usage:
```ts
const tx = makeSmartContractDeploy(<args>, {
    postConditions: myConditions,
    postConditionsMode: PostConditionMode.Allow,
}).serialize();
```

Previously, this required modifying a property on the intermediate tx object before serialization. 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
