### PR TITLE
fix: invalid private key length generated from `StacksPrivateKey.makeRandom`

### DIFF
--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -225,6 +225,7 @@ export class SpendingCondition extends StacksMessage {
       this.addressHashMode === AddressHashMode.SerializeP2WSH
     ) {
       // TODO
+      throw new Error(`Not yet implemented: serializing AddressHashMode: ${this.addressHashMode}`);
     }
 
     return bufferArray.concatBuffer();
@@ -307,7 +308,9 @@ export class Authorization extends StacksMessage {
         break;
       case AuthType.Sponsored:
         // TODO
-        break;
+        throw new Error('Not yet implemented: serializing sponsored transactions');
+      default:
+        throw new Error(`Unexpected transaction AuthType while serializing: ${this.authType}`);
     }
 
     return bufferArray.concatBuffer();
@@ -322,7 +325,9 @@ export class Authorization extends StacksMessage {
         break;
       case AuthType.Sponsored:
         // TODO
-        break;
+        throw new Error('Not yet implemented: deserializing sponsored transactions');
+      default:
+        throw new Error(`Unexpected transaction AuthType while deserializing: ${this.authType}`);
     }
   }
 }

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -77,7 +77,9 @@ export class StacksPrivateKey {
     } else if (key.length === 64) {
       this.compressed = false;
     } else {
-      throw new Error('Improperly formatted private-key hex string: length should be 64 or 66.');
+      throw new Error(
+        `Improperly formatted private-key hex string: length should be 64 or 66, provided with length ${key.length}`
+      );
     }
 
     this.data = Buffer.from(key, 'hex');
@@ -87,7 +89,7 @@ export class StacksPrivateKey {
     const ec = new EC('secp256k1');
     const options = { entropy: randomBytes(32) };
     const keyPair = ec.genKeyPair(options);
-    const privateKey = keyPair.getPrivate().toString('hex');
+    const privateKey = keyPair.getPrivate().toString('hex', 32);
     return new StacksPrivateKey(privateKey);
   }
 

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -98,7 +98,9 @@ export class Payload extends StacksMessage {
         bufferArray.push(this.coinbaseBuffer);
         break;
       default:
-        break;
+        throw new Error(
+          `Unexpected transaction payload type while serializing: ${this.payloadType}`
+        );
     }
 
     return bufferArray.concatBuffer();
@@ -134,7 +136,9 @@ export class Payload extends StacksMessage {
         this.coinbaseBuffer = bufferReader.read(COINBASE_BUFFER_LENGTH_BYTES);
         break;
       default:
-        break;
+        throw new Error(
+          `Unexpected transaction payload type while deserializing: ${this.payloadType}`
+        );
     }
   }
 }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -64,17 +64,19 @@ export class StacksTransaction extends StacksMessage {
 
     if (payload !== undefined) {
       switch (payload.payloadType) {
-        case PayloadType.Coinbase: {
-          this.anchorMode = AnchorMode.OnChainOnly;
-          break;
-        }
+        case PayloadType.Coinbase:
         case PayloadType.PoisonMicroblock: {
           this.anchorMode = AnchorMode.OnChainOnly;
           break;
         }
-        default: {
+        case PayloadType.ContractCall:
+        case PayloadType.SmartContract:
+        case PayloadType.TokenTransfer: {
           this.anchorMode = AnchorMode.Any;
           break;
+        }
+        default: {
+          throw new Error(`Unexpected transaction payload type: ${payload.payloadType}`);
         }
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,7 +120,10 @@ export class Address extends StacksMessage {
       case AddressHashMode.SerializeP2PKH:
         return Address.fromData(version, hash_p2pkh(publicKeys[0].toString()));
       default:
-        return new Address('');
+        // TODO
+        throw new Error(
+          `Not yet implemented: address construction using public keys for hash mode: ${hashMode}`
+        );
     }
   }
 


### PR DESCRIPTION
## Description

I've been running into intermittent invalid private key generation. The problem was a BN.js `toString('hex')` call not performing any padding. 

The following test could trigger the error in the previous code:
```ts
test('Stacks key generation', () => {
  for (let i = 0; i < 1000; i++) {
    StacksPrivateKey.makeRandom();
  }
});
```

This would often result in 63-char length keys like:
`9aa98e0581c44ca257519215f3a8246fbe6f659dede388c147bacc8f2960986` vs the correct result:
`09aa98e0581c44ca257519215f3a8246fbe6f659dede388c147bacc8f2960986`


Also added error handling to several conditionals that would silently fail or result in hard to track down errors later on. 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
