### PR TITLE
Async builder function signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ const options = {
   nonce: new BigNum(0) // The nonce needs to be manually specified for now
 };
 
-const transaction = makeSTXTokenTransfer(
+const transaction = await makeSTXTokenTransfer(
   recipientAddress,
   amount,
   feeRate,
@@ -73,7 +73,7 @@ const options = {
   nonce: new BigNum(0) // The nonce needs to be manually specified for now
 };
 
-const transaction = makeSmartContractDeploy(
+const transaction = await makeSmartContractDeploy(
   contractName, 
   code, 
   feeRate, 
@@ -118,7 +118,7 @@ const options = {
   nonce: new BigNum(0) // The nonce needs to be manually specified for now
 };
 
-const transaction = makeContractCall(
+const transaction = await makeContractCall(
   contractAddress,
   contractName,
   functionName,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4683,8 +4683,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4705,14 +4704,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4727,20 +4724,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4857,8 +4851,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4870,7 +4863,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4885,7 +4877,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4893,14 +4884,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4919,7 +4908,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5009,8 +4997,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5022,7 +5009,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5108,8 +5094,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5145,7 +5130,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5165,7 +5149,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5209,14 +5192,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -16,6 +16,7 @@ import {
 } from './postcondition';
 
 import {
+  DEFAULT_CORE_NODE_API_URL,
   TransactionVersion,
   AddressHashMode,
   FungibleConditionCode,
@@ -43,6 +44,7 @@ import * as BigNum from 'bn.js';
  */
 export interface TokenTransferOptions {
   nonce?: BigNum;
+  coreNodeUrl?: string;
   version?: TransactionVersion;
   memo?: string;
   postConditionMode?: PostConditionMode;
@@ -52,7 +54,7 @@ export interface TokenTransferOptions {
 /**
  * Generates a Stacks token transfer transaction
  *
- * Returns a signed Stacks token transfer transaction.
+ * Returns a promise that resolves to a signed Stacks token transfer transaction.
  *
  * @param  {String} recipientAddress - the c32check address of the recipient
  * @param  {BigNum} amount - number of tokens to transfer in microstacks
@@ -60,17 +62,18 @@ export interface TokenTransferOptions {
  * @param  {String} senderKey - hex string sender private key used to sign transaction
  * @param  {TokenTransferOptions} options - an options object for the token transfer
  *
- * @return {StacksTransaction}
+ * @return {Promise<StacksTransaction>}
  */
-export function makeSTXTokenTransfer(
+export async function makeSTXTokenTransfer(
   recipientAddress: string,
   amount: BigNum,
   feeRate: BigNum,
   senderKey: string,
   options?: TokenTransferOptions
-): StacksTransaction {
+): Promise<StacksTransaction> {
   const defaultOptions = {
     nonce: new BigNum(0),
+    coreNodeUrl: DEFAULT_CORE_NODE_API_URL,
     version: TransactionVersion.Mainnet,
     memo: '',
     postConditionMode: PostConditionMode.Deny,
@@ -103,7 +106,7 @@ export function makeSTXTokenTransfer(
   const signer = new TransactionSigner(transaction);
   signer.signOrigin(privKey);
 
-  return transaction;
+  return Promise.resolve(transaction);
 }
 
 /**
@@ -118,6 +121,7 @@ export function makeSTXTokenTransfer(
  */
 export interface ContractDeployOptions {
   nonce?: BigNum;
+  coreNodeUrl?: string;
   version?: TransactionVersion;
   postConditionMode?: PostConditionMode;
   postConditions?: PostCondition[];
@@ -126,24 +130,25 @@ export interface ContractDeployOptions {
 /**
  * Generates a Clarity smart contract deploy transaction
  *
- * Returns a signed Stacks smart contract deploy transaction.
+ * Returns a promise that resolves to a signed Stacks smart contract deploy transaction.
  *
  * @param  {String} contractName - the contract name
  * @param  {String} codeBody - the code body string
  * @param  {BigNum} feeRate - transaction fee rate in microstacks
  * @param  {String} senderKey - hex string sender private key used to sign transaction
  *
- * @return {StacksTransaction}
+ * @return {Promise<StacksTransaction>}
  */
-export function makeSmartContractDeploy(
+export async function makeSmartContractDeploy(
   contractName: string,
   codeBody: string,
   feeRate: BigNum,
   senderKey: string,
   options?: ContractDeployOptions
-): StacksTransaction {
+): Promise<StacksTransaction> {
   const defaultOptions = {
     nonce: new BigNum(0),
+    coreNodeUrl: DEFAULT_CORE_NODE_API_URL,
     version: TransactionVersion.Mainnet,
     postConditionMode: PostConditionMode.Deny,
   };
@@ -175,7 +180,7 @@ export function makeSmartContractDeploy(
   const signer = new TransactionSigner(transaction);
   signer.signOrigin(privKey);
 
-  return transaction;
+  return Promise.resolve(transaction);
 }
 
 /**
@@ -190,6 +195,7 @@ export function makeSmartContractDeploy(
  */
 export interface ContractCallOptions {
   nonce?: BigNum;
+  coreNodeUrl?: string;
   version?: TransactionVersion;
   postConditionMode?: PostConditionMode;
   postConditions?: PostCondition[];
@@ -198,7 +204,7 @@ export interface ContractCallOptions {
 /**
  * Generates a Clarity smart contract function call transaction
  *
- * Returns a signed Stacks smart contract deploy transaction.
+ * Returns a promise that resolves to a signed Stacks smart contract deploy transaction.
  *
  * @param  {String} contractAddress - the c32check address of the contract
  * @param  {String} contractName - the contract name
@@ -209,9 +215,9 @@ export interface ContractCallOptions {
  * @param  {String} senderKey - hex string sender private key used to sign transaction
  * @param  {TransactionVersion} version - can be set to mainnet or testnet
  *
- * @return {StacksTransaction}
+ * @return {Promise<StacksTransaction>}
  */
-export function makeContractCall(
+export async function makeContractCall(
   contractAddress: string,
   contractName: string,
   functionName: string,
@@ -219,9 +225,10 @@ export function makeContractCall(
   feeRate: BigNum,
   senderKey: string,
   options?: ContractCallOptions
-): StacksTransaction {
+): Promise<StacksTransaction> {
   const defaultOptions = {
     nonce: new BigNum(0),
+    coreNodeApiUrl: DEFAULT_CORE_NODE_API_URL,
     version: TransactionVersion.Mainnet,
     postConditionMode: PostConditionMode.Deny,
   };
@@ -258,7 +265,7 @@ export function makeContractCall(
   const signer = new TransactionSigner(transaction);
   signer.signOrigin(privKey);
 
-  return transaction;
+  return Promise.resolve(transaction);
 }
 
 /**

--- a/tests/src/builder-tests.ts
+++ b/tests/src/builder-tests.ts
@@ -25,7 +25,7 @@ import { bufferCV } from '../../src/clarity';
 
 import * as BigNum from 'bn.js';
 
-test('Make STX token transfer', () => {
+test('Make STX token transfer', async () => {
   const recipientAddress = 'SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159';
   const amount = new BigNum(12345);
   const feeRate = new BigNum(0);
@@ -36,7 +36,13 @@ test('Make STX token transfer', () => {
     memo: memo,
   };
 
-  const transaction = makeSTXTokenTransfer(recipientAddress, amount, feeRate, secretKey, options);
+  const transaction = await makeSTXTokenTransfer(
+    recipientAddress,
+    amount,
+    feeRate,
+    secretKey,
+    options
+  );
 
   const serialized = transaction.serialize().toString('hex');
 
@@ -50,7 +56,7 @@ test('Make STX token transfer', () => {
   expect(serialized).toBe(tx);
 });
 
-test('Make STX token transfer with post conditions', () => {
+test('Make STX token transfer with post conditions', async () => {
   const recipientAddress = 'SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159';
   const amount = new BigNum(12345);
   const feeRate = new BigNum(0);
@@ -70,7 +76,13 @@ test('Make STX token transfer with post conditions', () => {
     postConditions,
   };
 
-  const transaction = makeSTXTokenTransfer(recipientAddress, amount, feeRate, secretKey, options);
+  const transaction = await makeSTXTokenTransfer(
+    recipientAddress,
+    amount,
+    feeRate,
+    secretKey,
+    options
+  );
 
   const serialized = transaction.serialize().toString('hex');
 
@@ -84,7 +96,7 @@ test('Make STX token transfer with post conditions', () => {
   expect(serialized).toBe(tx);
 });
 
-test('Make smart contract deploy', () => {
+test('Make smart contract deploy', async () => {
   const contractName = 'kv-store';
   const code = fs.readFileSync('./tests/src/contracts/kv-store.clar').toString();
   const secretKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
@@ -94,7 +106,13 @@ test('Make smart contract deploy', () => {
     version: TransactionVersion.Testnet,
   };
 
-  const transaction = makeSmartContractDeploy(contractName, code, feeRate, secretKey, options);
+  const transaction = await makeSmartContractDeploy(
+    contractName,
+    code,
+    feeRate,
+    secretKey,
+    options
+  );
 
   const serialized = transaction.serialize().toString('hex');
 
@@ -114,7 +132,7 @@ test('Make smart contract deploy', () => {
   expect(serialized).toBe(tx);
 });
 
-test('Make contract-call', () => {
+test('Make contract-call', async () => {
   const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
   const contractName = 'kv-store';
   const functionName = 'get-value';
@@ -128,7 +146,7 @@ test('Make contract-call', () => {
     version: TransactionVersion.Testnet,
   };
 
-  const transaction = makeContractCall(
+  const transaction = await makeContractCall(
     contractAddress,
     contractName,
     functionName,
@@ -149,7 +167,7 @@ test('Make contract-call', () => {
   expect(serialized).toBe(tx);
 });
 
-test('Make contract-call with post conditions', () => {
+test('Make contract-call with post conditions', async () => {
   const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
   const contractName = 'kv-store';
   const functionName = 'get-value';
@@ -211,7 +229,7 @@ test('Make contract-call with post conditions', () => {
     postConditMode: PostConditionMode.Deny,
   };
 
-  const transaction = makeContractCall(
+  const transaction = await makeContractCall(
     contractAddress,
     contractName,
     functionName,
@@ -243,7 +261,7 @@ test('Make contract-call with post conditions', () => {
   expect(serialized).toBe(tx);
 });
 
-test('Make contract-call with post condition allow mode', () => {
+test('Make contract-call with post condition allow mode', async () => {
   const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
   const contractName = 'kv-store';
   const functionName = 'get-value';
@@ -258,7 +276,7 @@ test('Make contract-call with post condition allow mode', () => {
     postConditMode: PostConditionMode.Allow,
   };
 
-  const transaction = makeContractCall(
+  const transaction = await makeContractCall(
     contractAddress,
     contractName,
     functionName,


### PR DESCRIPTION
This PR makes the transaction builder functions async. This is to enable automatic handling of nonce values in the future. The nonce value will be retrieved from a core node API and requires a network request. 

Builder functions affected:
`makeSTXTokenTransfer`
`makeSmartContractDeploy`
`makeContractCall`

New usage example:
```
const transaction = await makeSTXTokenTransfer(...);
```
or
```
makeSTXTokenTransfer(...).then((transaction) => {
  // do something with transaction
});
```

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
Yes
`makeSTXTokenTransfer`
`makeSmartContractDeploy`
`makeContractCall`

## Are documentation updates required?
Yes.

## Testing information
`npm run test`

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
