### PR TITLE
Change all references of transaction fee rate to a total fee

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const BigNum = require('bn.js');
 
 const recipientAddress = 'SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159';
 const amount = new BigNum(12345);
-const feeRate = new BigNum(0); // Fee estimation to be implemented
+const fee = new BigNum(0); // Fee estimation to be implemented
 const secretKey = 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01';
 
 const options = {
@@ -49,7 +49,7 @@ const options = {
 const transaction = makeSTXTokenTransfer(
   recipientAddress,
   amount,
-  feeRate,
+  fee,
   secretKey,
   options
 );
@@ -67,7 +67,7 @@ const BigNum = require('bn.js');
 const contractName = 'contract_name';
 const code = fs.readFileSync('/path/to/contract.clar').toString();
 const secretKey = 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01';
-const feeRate = new BigNum(0); // Fee estimation to be implemented
+const fee = new BigNum(0); // Fee estimation to be implemented
 
 const options = {
   nonce: new BigNum(0) // The nonce needs to be manually specified for now
@@ -76,7 +76,7 @@ const options = {
 const transaction = makeSmartContractDeploy(
   contractName, 
   code, 
-  feeRate, 
+  fee, 
   secretKey
   options
 );
@@ -98,7 +98,7 @@ const buffer = Buffer.from('foo');
 const bufferClarityValue = new BufferCV(buffer);
 const functionArgs = [bufferClarityValue];
 const secretKey = 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01';
-const feeRate = new BigNum(0); // Fee estimation to be implemented
+const fee = new BigNum(0); // Fee estimation to be implemented
 
 // Add an optional post condition
 // See below for details on constructing post conditions
@@ -123,7 +123,7 @@ const transaction = makeContractCall(
   contractName,
   functionName,
   functionArgs,
-  feeRate,
+  fee,
   secretKey,
   options
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/stacks-transactions",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0-alpha.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4683,8 +4683,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4705,14 +4704,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4727,20 +4724,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4857,8 +4851,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4870,7 +4863,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4885,7 +4877,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4893,14 +4884,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4919,7 +4908,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5009,8 +4997,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5022,7 +5009,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5108,8 +5094,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5145,7 +5130,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5165,7 +5149,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5209,14 +5192,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -82,12 +82,7 @@ export class SpendingCondition extends Deserializable {
   signature: MessageSignature;
   signaturesRequired?: number;
 
-  constructor(
-    addressHashMode?: AddressHashMode,
-    pubKey?: string,
-    nonce?: BigNum,
-    fee?: BigNum
-  ) {
+  constructor(addressHashMode?: AddressHashMode, pubKey?: string, nonce?: BigNum, fee?: BigNum) {
     super();
     this.addressHashMode = addressHashMode;
     if (addressHashMode !== undefined && pubKey) {
@@ -270,12 +265,7 @@ export class SpendingCondition extends Deserializable {
 }
 
 export class SingleSigSpendingCondition extends SpendingCondition {
-  constructor(
-    addressHashMode?: AddressHashMode,
-    pubKey?: string,
-    nonce?: BigNum,
-    fee?: BigNum
-  ) {
+  constructor(addressHashMode?: AddressHashMode, pubKey?: string, nonce?: BigNum, fee?: BigNum) {
     super(addressHashMode, pubKey, nonce, fee);
     this.signaturesRequired = 1;
   }

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -74,7 +74,7 @@ export interface TokenTransferOptions {
  *
  * @param  {String} recipientAddress - the c32check address of the recipient
  * @param  {BigNum} amount - number of tokens to transfer in microstacks
- * @param  {BigNum} feeRate - transaction fee rate in microstacks
+ * @param  {BigNum} fee - transaction fee in microstacks
  * @param  {String} senderKey - hex string sender private key used to sign transaction
  * @param  {TokenTransferOptions} options - an options object for the token transfer
  *
@@ -83,7 +83,7 @@ export interface TokenTransferOptions {
 export function makeSTXTokenTransfer(
   recipient: string | PrincipalCV,
   amount: BigNum,
-  feeRate: BigNum,
+  fee: BigNum,
   senderKey: string,
   options?: TokenTransferOptions
 ): StacksTransaction {
@@ -107,7 +107,7 @@ export function makeSTXTokenTransfer(
     addressHashMode,
     publicKeyToString(pubKey),
     normalizedOptions.nonce,
-    feeRate
+    fee
   );
   const authorization = new StandardAuthorization(spendingCondition);
 
@@ -161,7 +161,7 @@ export interface ContractDeployOptions {
  *
  * @param  {String} contractName - the contract name
  * @param  {String} codeBody - the code body string
- * @param  {BigNum} feeRate - transaction fee rate in microstacks
+ * @param  {BigNum} fee - transaction fee in microstacks
  * @param  {String} senderKey - hex string sender private key used to sign transaction
  *
  * @return {StacksTransaction}
@@ -169,7 +169,7 @@ export interface ContractDeployOptions {
 export function makeSmartContractDeploy(
   contractName: string,
   codeBody: string,
-  feeRate: BigNum,
+  fee: BigNum,
   senderKey: string,
   options?: ContractDeployOptions
 ): StacksTransaction {
@@ -192,7 +192,7 @@ export function makeSmartContractDeploy(
     addressHashMode,
     publicKeyToString(pubKey),
     normalizedOptions.nonce,
-    feeRate
+    fee
   );
   const authorization = new StandardAuthorization(spendingCondition);
 
@@ -248,7 +248,7 @@ export interface ContractCallOptions {
  * @param  {String} contractName - the contract name
  * @param  {String} functionName - name of the function to be called
  * @param  {[ClarityValue]} functionArgs - an array of Clarity values as arguments to the function call
- * @param  {BigNum} feeRate - transaction fee rate in microstacks
+ * @param  {BigNum} fee - transaction fee rate in microstacks
  * @param  {BigNum} nonce - a nonce must be increased monotonically with each new transaction
  * @param  {String} senderKey - hex string sender private key used to sign transaction
  * @param  {TransactionVersion} version - can be set to mainnet or testnet
@@ -260,7 +260,7 @@ export function makeContractCall(
   contractName: string,
   functionName: string,
   functionArgs: ClarityValue[],
-  feeRate: BigNum,
+  fee: BigNum,
   senderKey: string,
   options?: ContractCallOptions
 ): StacksTransaction {
@@ -288,7 +288,7 @@ export function makeContractCall(
     addressHashMode,
     publicKeyToString(pubKey),
     normalizedOptions.nonce,
-    feeRate
+    fee
   );
   const authorization = new StandardAuthorization(spendingCondition);
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -89,8 +89,8 @@ export class StacksTransaction {
     authType: AuthType,
     privateKey: StacksPrivateKey
   ): string {
-    if (condition.feeRate === undefined) {
-      throw new Error('"condition.feeRate" is undefined');
+    if (condition.fee === undefined) {
+      throw new Error('"condition.fee" is undefined');
     }
     if (condition.nonce === undefined) {
       throw new Error('"condition.nonce" is undefined');
@@ -98,7 +98,7 @@ export class StacksTransaction {
     const { nextSig, nextSigHash } = SpendingCondition.nextSignature(
       curSigHash,
       authType,
-      condition.feeRate,
+      condition.fee,
       condition.nonce,
       privateKey
     );

--- a/tests/src/authorization-tests.ts
+++ b/tests/src/authorization-tests.ts
@@ -26,26 +26,26 @@ test('ECDSA recoverable signature', () => {
 test('Single spending condition serialization and deserialization', () => {
   const addressHashMode = AddressHashMode.SerializeP2PKH;
   const nonce = new BigNum(0);
-  const feeRate = new BigNum(0);
+  const fee = new BigNum(0);
   const pubKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
   const secretKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01';
-  const spendingCondition = new SingleSigSpendingCondition(addressHashMode, pubKey, nonce, feeRate);
+  const spendingCondition = new SingleSigSpendingCondition(addressHashMode, pubKey, nonce, fee);
   const emptySignature = MessageSignature.empty();
 
   const serialized = spendingCondition.serialize();
   const deserialized = SpendingCondition.deserialize(new BufferReader(serialized));
   expect(deserialized.addressHashMode).toBe(addressHashMode);
   expect(deserialized.nonce!.toNumber()).toBe(nonce.toNumber());
-  expect(deserialized.feeRate!.toNumber()).toBe(feeRate.toNumber());
+  expect(deserialized.fee!.toNumber()).toBe(fee.toNumber());
   expect(deserialized.signature.toString()).toBe(emptySignature.toString());
 });
 
 test('Single sig spending condition uncompressed', () => {
   const addressHashMode = AddressHashMode.SerializeP2PKH;
   const nonce = new BigNum(123);
-  const feeRate = new BigNum(456);
+  const fee = new BigNum(456);
   const pubKey = '';
-  const spendingCondition = new SingleSigSpendingCondition(addressHashMode, pubKey, nonce, feeRate);
+  const spendingCondition = new SingleSigSpendingCondition(addressHashMode, pubKey, nonce, fee);
   spendingCondition.signerAddress = addressFromVersionHash(
     AddressVersion.MainnetSingleSig,
     '11'.repeat(20)
@@ -85,9 +85,9 @@ test('Single sig spending condition uncompressed', () => {
 test('Single sig wpkh spending condition compressed', () => {
   const addressHashMode = AddressHashMode.SerializeP2WPKH;
   const nonce = new BigNum(345);
-  const feeRate = new BigNum(456);
+  const fee = new BigNum(456);
   const pubKey = '';
-  const spendingCondition = new SingleSigSpendingCondition(addressHashMode, pubKey, nonce, feeRate);
+  const spendingCondition = new SingleSigSpendingCondition(addressHashMode, pubKey, nonce, fee);
   spendingCondition.signerAddress = addressFromVersionHash(
     AddressVersion.MainnetSingleSig,
     '11'.repeat(20)

--- a/tests/src/builder-tests.ts
+++ b/tests/src/builder-tests.ts
@@ -29,7 +29,7 @@ import * as BigNum from 'bn.js';
 test('Make STX token transfer', () => {
   const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
   const amount = new BigNum(12345);
-  const feeRate = new BigNum(0);
+  const fee = new BigNum(0);
   const secretKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01';
   const memo = 'test memo';
 
@@ -37,7 +37,7 @@ test('Make STX token transfer', () => {
     memo: memo,
   };
 
-  const transaction = makeSTXTokenTransfer(recipient, amount, feeRate, secretKey, options);
+  const transaction = makeSTXTokenTransfer(recipient, amount, fee, secretKey, options);
 
   const serialized = transaction.serialize().toString('hex');
 
@@ -54,11 +54,11 @@ test('Make STX token transfer', () => {
 test('Make STX token transfer with testnet', () => {
   const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
   const amount = new BigNum(12345);
-  const feeRate = new BigNum(0);
+  const fee = new BigNum(0);
   const secretKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01';
   const memo = 'test memo';
 
-  const transaction = makeSTXTokenTransfer(recipient, amount, feeRate, secretKey, {
+  const transaction = makeSTXTokenTransfer(recipient, amount, fee, secretKey, {
     version: TransactionVersion.Testnet,
     chainId: ChainID.Testnet,
     memo: memo,
@@ -79,7 +79,7 @@ test('Make STX token transfer with testnet', () => {
 test('Make STX token transfer with post conditions', () => {
   const recipientAddress = 'SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159';
   const amount = new BigNum(12345);
-  const feeRate = new BigNum(0);
+  const fee = new BigNum(0);
   const secretKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01';
   const memo = 'test memo';
 
@@ -99,7 +99,7 @@ test('Make STX token transfer with post conditions', () => {
   const transaction = makeSTXTokenTransfer(
     standardPrincipalCV(recipientAddress),
     amount,
-    feeRate,
+    fee,
     secretKey,
     options
   );
@@ -120,13 +120,13 @@ test('Make smart contract deploy', () => {
   const contractName = 'kv-store';
   const code = fs.readFileSync('./tests/src/contracts/kv-store.clar').toString();
   const secretKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
-  const feeRate = new BigNum(0);
+  const fee = new BigNum(0);
 
   const options = {
     version: TransactionVersion.Testnet,
   };
 
-  const transaction = makeSmartContractDeploy(contractName, code, feeRate, secretKey, options);
+  const transaction = makeSmartContractDeploy(contractName, code, fee, secretKey, options);
 
   const serialized = transaction.serialize().toString('hex');
 
@@ -153,7 +153,7 @@ test('Make contract-call', () => {
   const buffer = bufferCV(Buffer.from('foo'));
   const secretKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
 
-  const feeRate = new BigNum(0);
+  const fee = new BigNum(0);
 
   const options = {
     nonce: new BigNum(1),
@@ -165,7 +165,7 @@ test('Make contract-call', () => {
     contractName,
     functionName,
     [buffer],
-    feeRate,
+    fee,
     secretKey,
     options
   );
@@ -194,7 +194,7 @@ test('Make contract-call with post conditions', () => {
   const info = createAssetInfo(assetAddress, assetContractName, assetName);
   const tokenAssetName = 'token-asset-name';
 
-  const feeRate = new BigNum(0);
+  const fee = new BigNum(0);
 
   const postConditions = [
     makeStandardSTXPostCondition(
@@ -241,7 +241,7 @@ test('Make contract-call with post conditions', () => {
     contractName,
     functionName,
     [buffer],
-    feeRate,
+    fee,
     secretKey,
     {
       nonce: new BigNum(1),
@@ -280,14 +280,14 @@ test('Make contract-call with post condition allow mode', () => {
   const buffer = bufferCV(Buffer.from('foo'));
   const secretKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
 
-  const feeRate = new BigNum(0);
+  const fee = new BigNum(0);
 
   const transaction = makeContractCall(
     contractAddress,
     contractName,
     functionName,
     [buffer],
-    feeRate,
+    fee,
     secretKey,
     {
       nonce: new BigNum(1),

--- a/tests/src/transaction-tests.ts
+++ b/tests/src/transaction-tests.ts
@@ -49,10 +49,10 @@ test('STX token transfer transaction serialization and deserialization', () => {
 
   const addressHashMode = AddressHashMode.SerializeP2PKH;
   const nonce = new BigNum(0);
-  const feeRate = new BigNum(0);
+  const fee = new BigNum(0);
   const pubKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
   const secretKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01';
-  const spendingCondition = new SingleSigSpendingCondition(addressHashMode, pubKey, nonce, feeRate);
+  const spendingCondition = new SingleSigSpendingCondition(addressHashMode, pubKey, nonce, fee);
   const authType = AuthType.Standard;
   const authorization = new StandardAuthorization(spendingCondition);
 
@@ -83,7 +83,7 @@ test('STX token transfer transaction serialization and deserialization', () => {
   expect(deserialized.auth.authType).toBe(authType);
   expect(deserialized.auth.spendingCondition!.addressHashMode).toBe(addressHashMode);
   expect(deserialized.auth.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
-  expect(deserialized.auth.spendingCondition!.feeRate!.toNumber()).toBe(feeRate.toNumber());
+  expect(deserialized.auth.spendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
   expect(deserialized.anchorMode).toBe(anchorMode);
   expect(deserialized.postConditionMode).toBe(postConditionMode);
   expect(deserialized.postConditions.values.length).toBe(1);
@@ -110,10 +110,10 @@ test('Transaction broadcast', () => {
 
   const addressHashMode = AddressHashMode.SerializeP2PKH;
   const nonce = new BigNum(0);
-  const feeRate = new BigNum(0);
+  const fee = new BigNum(0);
   const pubKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
   const secretKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01';
-  const spendingCondition = new SingleSigSpendingCondition(addressHashMode, pubKey, nonce, feeRate);
+  const spendingCondition = new SingleSigSpendingCondition(addressHashMode, pubKey, nonce, fee);
   const authorization = new StandardAuthorization(spendingCondition);
 
   const transaction = new StacksTransaction(transactionVersion, authorization, payload);


### PR DESCRIPTION
This PR changes all references of fee "rate" to a total fee. This brings it in line with what's actually implemented on core. The wire format specified in [SIP005](https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-005-blocks-and-transactions.md#transaction-encoding) needs to be updated as well. This change is needed because downstream integrations erroneously input a fee rate per byte instead of a total fee when building transactions, leading to the transaction being rejected for having a fee that's too low. 

Related to: 
https://github.com/blockstack/stacks-transactions-js/issues/55
https://github.com/blockstack/stacks-transactions-js/issues/54

## Type of Change
- [ ] New feature
- [x] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
Not a breaking change.

## Are documentation updates required?
Yes

## Testing information
Transactions built with the lib should continue to function when the fee is set correctly.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
