### PR TITLE
Support strings for contract principals and asset info IDs

### DIFF
--- a/src/builders.ts
+++ b/src/builders.ts
@@ -34,13 +34,7 @@ import {
   AnchorMode,
 } from './constants';
 
-import {
-  AssetInfo,
-  createLPList,
-  createStandardPrincipal,
-  createContractPrincipal,
-  createLPString,
-} from './types';
+import { AssetInfo, createLPList, createStandardPrincipal, createContractPrincipal } from './types';
 
 import * as BigNum from 'bn.js';
 import { ClarityValue, PrincipalCV } from './clarity';
@@ -376,7 +370,7 @@ export function makeStandardFungiblePostCondition(
   address: string,
   conditionCode: FungibleConditionCode,
   amount: BigNum,
-  assetInfo: AssetInfo
+  assetInfo: string | AssetInfo
 ): FungiblePostCondition {
   return createFungiblePostCondition(
     createStandardPrincipal(address),
@@ -404,7 +398,7 @@ export function makeContractFungiblePostCondition(
   contractName: string,
   conditionCode: FungibleConditionCode,
   amount: BigNum,
-  assetInfo: AssetInfo
+  assetInfo: string | AssetInfo
 ): FungiblePostCondition {
   return createFungiblePostCondition(
     createContractPrincipal(address, contractName),
@@ -428,7 +422,7 @@ export function makeContractFungiblePostCondition(
 export function makeStandardNonFungiblePostCondition(
   address: string,
   conditionCode: NonFungibleConditionCode,
-  assetInfo: AssetInfo,
+  assetInfo: string | AssetInfo,
   assetName: ClarityValue
 ): NonFungiblePostCondition {
   return createNonFungiblePostCondition(
@@ -455,7 +449,7 @@ export function makeContractNonFungiblePostCondition(
   address: string,
   contractName: string,
   conditionCode: NonFungibleConditionCode,
-  assetInfo: AssetInfo,
+  assetInfo: string | AssetInfo,
   assetName: ClarityValue
 ): NonFungiblePostCondition {
   return createNonFungiblePostCondition(

--- a/src/postcondition.ts
+++ b/src/postcondition.ts
@@ -14,8 +14,8 @@ import {
   PostConditionPrincipal,
   serializePrincipal,
   deserializePrincipal,
-  createStandardPrincipal,
-  createAssetInfo,
+  parseAssetInfoString,
+  parsePrincipalString,
 } from './types';
 
 import * as BigNum from 'bn.js';
@@ -38,7 +38,7 @@ export function createSTXPostCondition(
   amount: BigNum
 ): STXPostCondition {
   if (typeof principal === 'string') {
-    principal = createStandardPrincipal(principal);
+    principal = parsePrincipalString(principal);
   }
 
   return {
@@ -63,10 +63,13 @@ export function createFungiblePostCondition(
   principal: string | PostConditionPrincipal,
   conditionCode: FungibleConditionCode,
   amount: BigNum,
-  assetInfo: AssetInfo
+  assetInfo: string | AssetInfo
 ): FungiblePostCondition {
   if (typeof principal === 'string') {
-    principal = createStandardPrincipal(principal);
+    principal = parsePrincipalString(principal);
+  }
+  if (typeof assetInfo === 'string') {
+    assetInfo = parseAssetInfoString(assetInfo);
   }
 
   return {
@@ -93,11 +96,14 @@ export interface NonFungiblePostCondition {
 export function createNonFungiblePostCondition(
   principal: string | PostConditionPrincipal,
   conditionCode: NonFungibleConditionCode,
-  assetInfo: AssetInfo,
+  assetInfo: string | AssetInfo,
   assetName: ClarityValue
 ): NonFungiblePostCondition {
   if (typeof principal === 'string') {
-    principal = createStandardPrincipal(principal);
+    principal = parsePrincipalString(principal);
+  }
+  if (typeof assetInfo === 'string') {
+    assetInfo = parseAssetInfoString(assetInfo);
   }
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -224,6 +224,23 @@ export interface ContractPrincipal {
   readonly contractName: LengthPrefixedString;
 }
 
+/**
+ * Parses a principal string for either a standard principal or contract principal.
+ * @param principalString - String in the format `{address}.{contractName}`
+ * @example "SP13N5TE1FBBGRZD1FCM49QDGN32WAXM2E5F8WT2G.example-contract"
+ * @example "SP13N5TE1FBBGRZD1FCM49QDGN32WAXM2E5F8WT2G"
+ */
+export function parsePrincipalString(
+  principalString: string
+): StandardPrincipal | ContractPrincipal {
+  if (principalString.includes('.')) {
+    const [address, contractName] = principalString.split('.');
+    return createContractPrincipal(address, contractName);
+  } else {
+    return createStandardPrincipal(principalString);
+  }
+}
+
 export function createStandardPrincipal(addressString: string): StandardPrincipal {
   const addr = createAddress(addressString);
   return {
@@ -363,6 +380,17 @@ export interface AssetInfo {
   readonly address: Address;
   readonly contractName: LengthPrefixedString;
   readonly assetName: LengthPrefixedString;
+}
+
+/**
+ * Parse a fully qualified string that identifies the token type.
+ * @param id - String in the format `{address}.{contractName}::{assetName}`
+ * @example "SP13N5TE1FBBGRZD1FCM49QDGN32WAXM2E5F8WT2G.example-contract::example-token"
+ */
+export function parseAssetInfoString(id: string): AssetInfo {
+  const [assetAddress, assetContractName, assetTokenName] = id.split(/\.|::/);
+  const assetInfo = createAssetInfo(assetAddress, assetContractName, assetTokenName);
+  return assetInfo;
 }
 
 export function createAssetInfo(

--- a/tests/src/postcondition-tests.ts
+++ b/tests/src/postcondition-tests.ts
@@ -28,7 +28,7 @@ import {
 import { serializeDeserialize } from './macros';
 
 import * as BigNum from 'bn.js';
-import { bufferCVFromString, deserializeCV, BufferCV } from '../../src';
+import { bufferCVFromString, BufferCV } from '../../src';
 
 test('STX post condition serialization and deserialization', () => {
   const postConditionType = PostConditionType.STX;
@@ -102,6 +102,42 @@ test('Non-fungible post condition serialization and deserialization', () => {
     principal,
     conditionCode,
     info,
+    bufferCVFromString(nftAssetName)
+  );
+
+  const deserialized = serializeDeserialize(
+    postCondition,
+    StacksMessageType.PostCondition
+  ) as NonFungiblePostCondition;
+  expect(deserialized.conditionType).toBe(postConditionType);
+  expect(deserialized.principal.prefix).toBe(PostConditionPrincipalID.Contract);
+  expect(addressToString(deserialized.principal.address)).toBe(address);
+  expect((deserialized.principal as ContractPrincipal).contractName.content).toBe(contractName);
+  expect(deserialized.conditionCode).toBe(conditionCode);
+  expect(addressToString(deserialized.assetInfo.address)).toBe(assetAddress);
+  expect(deserialized.assetInfo.contractName.content).toBe(assetContractName);
+  expect(deserialized.assetInfo.assetName.content).toBe(assetName);
+  expect((deserialized.assetName as BufferCV).buffer.toString()).toEqual(nftAssetName);
+});
+
+test('Non-fungible post condition with string IDs serialization and deserialization', () => {
+  const postConditionType = PostConditionType.NonFungible;
+
+  const address = 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B';
+  const contractName = 'contract-name';
+
+  const conditionCode = NonFungibleConditionCode.Owns;
+
+  const assetAddress = 'SP2ZP4GJDZJ1FDHTQ963F0292PE9J9752TZJ68F21';
+  const assetContractName = 'contract_name';
+  const assetName = 'asset_name';
+
+  const nftAssetName = 'nft_asset_name';
+
+  const postCondition = createNonFungiblePostCondition(
+    `${address}.${contractName}`,
+    conditionCode,
+    `${assetAddress}.${assetContractName}::${assetName}`,
     bufferCVFromString(nftAssetName)
   );
 


### PR DESCRIPTION
## Description

Improves the DX for creating a post-conditions. Previously, several functions had to be discovered (e.g. `makeStandardNonFungiblePostCondition`, `makeContractNonFungiblePostCondition`, `createNonFungiblePostCondition`, `createAssetInfo`).

And the resulting code pretty verbose:
```ts
  const postCondition = createNonFungiblePostCondition(
    createContractPrincipal(
      'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B', 
      'contract-name'),
    NonFungibleConditionCode.Owns,
    createAssetInfo('SP2ZP4GJDZJ1FDHTQ963F0292PE9J9752TZJ68F21', 
      'contract_name', 
      'asset_name'),
    bufferCVFromString('nft_asset_name')
  );

// Note: more verbose when the inputs are strings that need to be split
// (e.g. `SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B.contract-name`)
```

These post conditions can now be constructed without distinguishing between principal types or requiring construction of the `AssetInfo` object:
```ts
  const postCondition = createNonFungiblePostCondition(
    'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B.contract-name',
    NonFungibleConditionCode.Owns,
    'SP2ZP4GJDZJ1FDHTQ963F0292PE9J9752TZJ68F21.contract_name::asset_name',
    bufferCVFromString('nft_asset_name')
  );
```

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
Backwards compatible

## Are documentation updates required?
## Testing information

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
