### PR TITLE
Add prepare script for git installs, fix build directory structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@blockstack/stacks-transactions",
   "version": "0.3.0-alpha.5",
   "description": "Javascript library for constructing transactions on the Stacks blockchain.",
-  "main": "lib/src/index",
-  "types": "lib/src/index.d.ts",
+  "main": "lib/index",
+  "types": "lib/index.d.ts",
   "unpkg": "dist/stacks-transactions.js",
   "scripts": {
     "build": "npm run build:node",
@@ -12,13 +12,14 @@
     "build:webpack:analyze": "shx rm -rf dist/* && cross-env NODE_ENV=production ANALYZE=true webpack --mode=production",
     "build:docs": "rimraf docs && cross-env typedoc --name \"stacks-transactions-js $npm_package_version Library Reference\" --tsconfig tsconfig.typedoc.json --out docs --json docs/docs.json src",
     "start": "webpack-dev-server",
-    "build:node": "shx rm -rf lib && tsc --declaration",
-    "build:node:watch": "shx rm -rf lib && tsc --watch",
+    "build:node": "shx rm -rf lib && tsc -p tsconfig.build.json",
+    "build:node:watch": "shx rm -rf lib && tsc -p tsconfig.build.json --watch",
     "lint": "eslint ./src ./tests --ext .ts",
     "lint:fix": "eslint ./src ./tests --ext .ts --fix",
     "test": "jest --config ./jest.config.js --coverage",
     "prepublishOnly": "npm run test && npm run build",
-    "typecheck": "tsc --noEmit"
+    "prepare": "npm run build",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "declaration": true,
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
## Description

Use the npm `prepare` script to make this lib usable when installed as a git dependency. This lib is under rapid development, and blocks staging deployments for dependent projects when a branch has not been merged & published to NPM. 

Additionally, this PR fixes the nested build output directory e.g. 
`@blockstack/stacks-transactions/lib/src/bufferReader` vs
`@blockstack/stacks-transactions/lib/bufferReader`
This was simply the build script missing a `tsconfig.build.json` param which excludes the `tests` dir from the output. 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
## Are documentation updates required?
## Testing information

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
