### PR TITLE
Fix pub key encoding hex value not properly converted to string

### DIFF
--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -7,7 +7,7 @@ import {
   RECOVERABLE_ECDSA_SIG_LENGTH_BYTES,
 } from './constants';
 
-import { BufferArray, txidFromData, sha512_256 } from './utils';
+import { BufferArray, txidFromData, sha512_256, leftPadHex } from './utils';
 
 import { Address, addressFromPublicKeys, addressFromVersionHash } from './types';
 
@@ -160,7 +160,7 @@ export class SpendingCondition extends Deserializable {
       ? PubKeyEncoding.Compressed
       : PubKeyEncoding.Uncompressed;
 
-    const sigHash = curSigHash + pubKeyEncoding.toString(16) + signature.toString();
+    const sigHash = curSigHash + leftPadHex(pubKeyEncoding.toString(16)) + signature.toString();
 
     if (Buffer.from(sigHash, 'hex').byteLength > hashLength) {
       throw Error('Invalid signature hash length');

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -160,7 +160,7 @@ export class SpendingCondition extends Deserializable {
       ? PubKeyEncoding.Compressed
       : PubKeyEncoding.Uncompressed;
 
-    const sigHash = curSigHash + pubKeyEncoding + signature.toString();
+    const sigHash = curSigHash + pubKeyEncoding.toString(16) + signature.toString();
 
     if (Buffer.from(sigHash, 'hex').byteLength > hashLength) {
       throw Error('Invalid signature hash length');


### PR DESCRIPTION
Fix pub key encoding hex value not properly converted to string for sig hash.

Potential fix for #58 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
Transaction generation should now work in browsers

For detailed steps to reproduce, see #58 

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
