### PR TITLE
Fetch nonce automatically in transaction builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const txOptions = {
   senderKey: 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01',
   network,
   memo: "test memo",
-  nonce: new BigNum(0),
+  nonce: new BigNum(0), // set a nonce manually if you don't want builder to fetch from a Stacks node
   fee: new BigNum(200), // set a tx fee if you don't want the builder to estimate
 };
 
@@ -73,7 +73,6 @@ const txOptions = {
   codeBody: fs.readFileSync('/path/to/contract.clar').toString();
   senderKey: 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01';
   network,
-  nonce: new BigNum(0) // The nonce needs to be manually specified for now
 };
 
 const transaction = await makeSmartContractDeploy(txOptions);
@@ -110,7 +109,6 @@ const txOptions = {
   senderKey: 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01',
   network,
   postConditions,
-  nonce: new BigNum(0) // The nonce needs to be manually specified for now
 };
 
 const transaction = await makeContractCall(txOptions);

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -301,6 +301,10 @@ export class Authorization extends Deserializable {
     this.spendingCondition!.fee = amount;
   }
 
+  setNonce(nonce: BigNum) {
+    this.spendingCondition!.nonce = nonce;
+  }
+
   serialize(): Buffer {
     const bufferArray: BufferArray = new BufferArray();
     if (this.authType === undefined) {

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -56,7 +56,7 @@ import { ClarityValue, PrincipalCV } from './clarity';
  * @return a promise that resolves to an integer
  */
 export function getNonce(address: string, network?: StacksNetwork): Promise<BigNum> {
-  return fetch(`${network?.balanceApiUrl}/${address}?proof=0`)
+  return fetchPrivate(`${network?.balanceApiUrl}/${address}?proof=0`)
     .then(response => response.json())
     .then(response => Promise.resolve(new BigNum(response.nonce)));
 }

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -10,7 +10,12 @@ import {
 
 import { SingleSigSpendingCondition, StandardAuthorization } from './authorization';
 
-import { publicKeyToString, createStacksPrivateKey, getPublicKey } from './keys';
+import {
+  publicKeyToString,
+  createStacksPrivateKey,
+  getPublicKey,
+  publicKeyToAddress,
+} from './keys';
 
 import { TransactionSigner } from './signer';
 
@@ -26,11 +31,13 @@ import {
 
 import {
   AddressHashMode,
+  AddressVersion,
   FungibleConditionCode,
   NonFungibleConditionCode,
   PostConditionMode,
   PayloadType,
   AnchorMode,
+  TransactionVersion,
 } from './constants';
 
 import { AssetInfo, createLPList, createStandardPrincipal, createContractPrincipal } from './types';
@@ -39,6 +46,20 @@ import { fetchPrivate } from './utils';
 
 import * as BigNum from 'bn.js';
 import { ClarityValue, PrincipalCV } from './clarity';
+
+/**
+ * Lookup the nonce for an address from a core node
+ *
+ * @param {string} address - the c32check address to look up
+ * @param {StacksNetwork} network - the Stacks network to look up address on
+ *
+ * @return a promise that resolves to an integer
+ */
+export function getNonce(address: string, network?: StacksNetwork): Promise<BigNum> {
+  return fetch(`${network?.balanceApiUrl}/${address}?proof=0`)
+    .then(response => response.json())
+    .then(response => Promise.resolve(new BigNum(response.nonce)));
+}
 
 /**
  * Estimate the total transaction fee in microstacks for a token transfer
@@ -201,6 +222,16 @@ export async function makeSTXTokenTransfer(
     transaction.setFee(txFee);
   }
 
+  if (!txOptions.nonce) {
+    const addressVersion =
+      options.network.version === TransactionVersion.Mainnet
+        ? AddressVersion.MainnetSingleSig
+        : AddressVersion.TestnetSingleSig;
+    const senderAddress = publicKeyToAddress(addressVersion, pubKey);
+    const txNonce = await getNonce(senderAddress, options.network);
+    transaction.setNonce(txNonce);
+  }
+
   if (options.senderKey) {
     const signer = new TransactionSigner(transaction);
     signer.signOrigin(privKey);
@@ -333,6 +364,16 @@ export async function makeSmartContractDeploy(
   if (!txOptions.fee) {
     const txFee = await estimateTransfer(transaction, options.network);
     transaction.setFee(txFee);
+  }
+
+  if (!txOptions.nonce) {
+    const addressVersion =
+      options.network.version === TransactionVersion.Mainnet
+        ? AddressVersion.MainnetSingleSig
+        : AddressVersion.TestnetSingleSig;
+    const senderAddress = publicKeyToAddress(addressVersion, pubKey);
+    const txNonce = await getNonce(senderAddress, options.network);
+    transaction.setNonce(txNonce);
   }
 
   if (options.senderKey) {
@@ -474,6 +515,16 @@ export async function makeContractCall(txOptions: ContractCallOptions): Promise<
   if (!txOptions.fee) {
     const txFee = await estimateContractFunctionCall(transaction, options.network);
     transaction.setFee(txFee);
+  }
+
+  if (!txOptions.nonce) {
+    const addressVersion =
+      options.network.version === TransactionVersion.Mainnet
+        ? AddressVersion.MainnetSingleSig
+        : AddressVersion.TestnetSingleSig;
+    const senderAddress = publicKeyToAddress(addressVersion, pubKey);
+    const txNonce = await getNonce(senderAddress, options.network);
+    transaction.setNonce(txNonce);
   }
 
   if (options.senderKey) {

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -4,12 +4,14 @@ import {
   StacksMessageType,
 } from './constants';
 
-import { BufferArray, leftPadHexToLength, intToHexString, randomBytes } from './utils';
+import { BufferArray, leftPadHexToLength, intToHexString, randomBytes, hash160 } from './utils';
 
 import { ec as EC } from 'elliptic';
 
 import { MessageSignature } from './authorization';
 import { BufferReader } from './bufferReader';
+import { AddressVersion } from './constants';
+import { c32address } from 'c32check';
 
 export interface StacksPublicKey {
   readonly type: StacksMessageType.PublicKey;
@@ -114,4 +116,8 @@ export function getPublicKey(privateKey: StacksPrivateKey): StacksPublicKey {
 
 export function privateKeyToString(privateKey: StacksPrivateKey): string {
   return privateKey.data.toString('hex');
+}
+
+export function publicKeyToAddress(version: AddressVersion, publicKey: StacksPublicKey): string {
+  return c32address(version, hash160(publicKey.data.toString('hex')));
 }

--- a/src/network.ts
+++ b/src/network.ts
@@ -6,6 +6,7 @@ export interface StacksNetwork {
   coreApiUrl: string;
   broadcastApiUrl: string;
   transferFeeEstimateApiUrl: string;
+  balanceApiUrl: string;
 }
 
 export class StacksMainnet implements StacksNetwork {
@@ -14,6 +15,7 @@ export class StacksMainnet implements StacksNetwork {
   coreApiUrl = 'https://core.blockstack.org';
   broadcastApiUrl = `${this.coreApiUrl}/v2/transactions`;
   transferFeeEstimateApiUrl = `${this.coreApiUrl}/v2/fees/transfer`;
+  balanceApiUrl = `${this.coreApiUrl}/v2/accounts`;
 }
 
 export class StacksTestnet implements StacksNetwork {
@@ -22,4 +24,5 @@ export class StacksTestnet implements StacksNetwork {
   coreApiUrl = 'http://neon.blockstack.org:20443';
   broadcastApiUrl = `${this.coreApiUrl}/v2/transactions`;
   transferFeeEstimateApiUrl = `${this.coreApiUrl}/v2/fees/transfer`;
+  balanceApiUrl = `${this.coreApiUrl}/v2/accounts`;
 }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -128,6 +128,15 @@ export class StacksTransaction {
     this.auth.setFee(amount);
   }
 
+  /**
+   * Set the transaction nonce
+   *
+   * @param {BigNum} nonce - the nonce value
+   */
+  setNonce(nonce: BigNum) {
+    this.auth.setNonce(nonce);
+  }
+
   serialize(): Buffer {
     if (this.version === undefined) {
       throw new Error('"version" is undefined');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,11 +66,6 @@ export const leftPadHexToLength = (hexString: string, length: number): string =>
 export const rightPadHexToLength = (hexString: string, length: number): string =>
   hexString.padEnd(length, '0');
 
-// export const bigIntToHexString = (integer: BigInt, lengthBytes: number = 8): string =>
-//   integer.toString(16).padStart(lengthBytes * 2, '0');
-
-// export const hexStringToBigInt = (hexString: string): BigInt => BigInt("0x" + hexString);
-
 export const intToHexString = (integer: number, lengthBytes = 8): string =>
   integer.toString(16).padStart(lengthBytes * 2, '0');
 


### PR DESCRIPTION
This PR updates the transaction builder functions to automatically fetch the account nonce from a Stacks node if a nonce is not specified. This saves a step and makes integration easier. Nonce can be set manually in the options arg.

Resolves #73

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
Readme updated.

## Testing information
Nonce should be fetched automatically in transaction builder when not specified via the options object.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
