### PR TITLE
fix: export broadcastTransaction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export {
   makeSmartContractDeploy,
   makeContractCall,
   estimateTransfer,
+  broadcastTransaction,
 } from './builders';
 
 export * from './network';


### PR DESCRIPTION
Bug fix:

Figured we need `broadcastTransaction` being exported from the main export.
