### PR TITLE
Validate Contract-Call Payload with ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to the project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+- ABI validation for contract-call transactions
+- Additional methods added to the StacksNetwork interface
+
+### Changed

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ const txOptions = {
   functionName: 'contract_function',
   functionArgs: [bufferCVFromString('foo')],
   senderKey: 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01',
+  validateWithAbi: true,
   network,
   postConditions,
 };
@@ -114,6 +115,14 @@ const txOptions = {
 const transaction = await makeContractCall(txOptions);
 
 broadcastTransaction(transaction, network);
+```
+
+In this example we construct a `contract-call` transaction with a post condition. We have set the `validateWithAbi` option to `true`, so the `makeContractCall` builder will attempt to fetch this contracts ABI from the specified Stacks network, and validate that the provided functionArgs match what is described in the ABI. This should help you avoid constructing invalid contract-call transactions. If you would prefer to provide your own ABI instead of fetching it from the network, the `validateWithABI` option also accepts [ClarityABI](https://github.com/blockstack/stacks-transactions-js/blob/master/src/contract-abi.ts#L231) objects, which can be constructed from ABI files like so:
+
+```typescript
+import { readFileSync } from 'fs';
+
+const abi: ClarityAbi = JSON.parse(readFileSync('abi.json').toString());
 ```
 
 ## Constructing Clarity Values

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -57,7 +57,12 @@ import { validateContractCall, ClarityAbi } from './contract-abi';
  * @return a promise that resolves to an integer
  */
 export function getNonce(address: string, network?: StacksNetwork): Promise<BigNum> {
-  return fetchPrivate(`${network?.balanceApiUrl}/${address}?proof=0`)
+  const defaultNetwork = new StacksMainnet();
+  const url = network
+    ? network.getAccountApiUrl(address)
+    : defaultNetwork.getAccountApiUrl(address);
+
+  return fetchPrivate(url)
     .then(response => response.json())
     .then(response => Promise.resolve(new BigNum(response.nonce)));
 }
@@ -89,8 +94,8 @@ export function estimateTransfer(
 
   const defaultNetwork = new StacksMainnet();
   const url = network
-    ? network.transferFeeEstimateApiUrl
-    : defaultNetwork.transferFeeEstimateApiUrl;
+    ? network.getTransferFeeEstimateApiUrl()
+    : defaultNetwork.getTransferFeeEstimateApiUrl();
 
   return fetchPrivate(url, fetchOptions)
     .then(response => response.text())
@@ -122,7 +127,7 @@ export function broadcastTransaction(transaction: StacksTransaction, network: St
     body: tx,
   };
 
-  const url = network.broadcastApiUrl;
+  const url = network.getBroadcastApiUrl();
 
   return fetchPrivate(url, options).then(response => {
     if (response.ok) {
@@ -326,8 +331,8 @@ export function estimateContractDeploy(
   // blockchain core
   const defaultNetwork = new StacksMainnet();
   const url = network
-    ? network.transferFeeEstimateApiUrl
-    : defaultNetwork.transferFeeEstimateApiUrl;
+    ? network.getTransferFeeEstimateApiUrl()
+    : defaultNetwork.getTransferFeeEstimateApiUrl();
 
   return fetchPrivate(url, fetchOptions)
     .then(response => response.text())
@@ -475,8 +480,8 @@ export function estimateContractFunctionCall(
   // blockchain core
   const defaultNetwork = new StacksMainnet();
   const url = network
-    ? network.transferFeeEstimateApiUrl
-    : defaultNetwork.transferFeeEstimateApiUrl;
+    ? network.getTransferFeeEstimateApiUrl()
+    : defaultNetwork.getTransferFeeEstimateApiUrl();
 
   return fetchPrivate(url, fetchOptions)
     .then(response => response.text())

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -114,7 +114,10 @@ export function estimateTransfer(
  *
  * @returns {Promise} that resolves to a response if the operation succeeds
  */
-export function broadcastTransaction(transaction: StacksTransaction, network: StacksNetwork) {
+export async function broadcastTransaction(
+  transaction: StacksTransaction,
+  network: StacksNetwork
+): Promise<string> {
   const tx = transaction.serialize();
 
   const requestHeaders = {
@@ -129,13 +132,18 @@ export function broadcastTransaction(transaction: StacksTransaction, network: St
 
   const url = network.getBroadcastApiUrl();
 
-  return fetchPrivate(url, options).then(response => {
-    if (response.ok) {
-      return response.text();
-    } else {
-      return response.text();
-    }
-  });
+  const response = await fetchPrivate(url, options);
+  if (!response.ok) {
+    let msg = '';
+    try {
+      msg = await response.text();
+    } catch (error) {}
+    throw new Error(
+      `Error broadcasting transaction. Response ${response.status}: ${response.statusText} fetching ${url} - ${msg}`
+    );
+  }
+
+  return response.text();
 }
 
 /**
@@ -158,13 +166,18 @@ export async function getAbi(
 
   const url = network.getAbiApiUrl(address, contractName);
 
-  return fetchPrivate(url, options).then(async response => {
-    if (response.ok) {
-      return JSON.parse(await response.text());
-    } else {
-      return response.text();
-    }
-  });
+  const response = await fetchPrivate(url, options);
+  if (!response.ok) {
+    let msg = '';
+    try {
+      msg = await response.text();
+    } catch (error) {}
+    throw new Error(
+      `Error fetching ABI. Response ${response.status}: ${response.statusText} fetching ${url} - ${msg}`
+    );
+  }
+
+  return JSON.parse(await response.text());
 }
 
 /**

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -507,7 +507,7 @@ export async function makeContractCall(txOptions: ContractCallOptions): Promise<
 
   if (options?.validateWithAbi) {
     if (options?.network) {
-      const abi = await getAbi(contractAddress, contractName, options.network);
+      const abi = await getAbi(options.contractAddress, options.contractName, options.network);
       validateContractCall(payload, abi);
     } else {
       throw new Error('Network option must be provided in order to validate with ABI');

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -133,6 +133,15 @@ export function broadcastTransaction(transaction: StacksTransaction, network: St
   });
 }
 
+/**
+ * Fetch a contract's ABI
+ *
+ * @param {string} address - the contracts address
+ * @param {string} contractName - the contracts name
+ * @param {Stacks} network - the Stacks network to broadcast transaction to
+ *
+ * @returns {Promise} that resolves to a ClarityAbi if the operation succeeds
+ */
 export async function getAbi(
   address: string,
   contractName: string,
@@ -506,7 +515,7 @@ export async function makeContractCall(txOptions: ContractCallOptions): Promise<
   );
 
   if (options?.validateWithAbi) {
-    let abi;
+    let abi: ClarityAbi;
     if (typeof options.validateWithAbi === 'boolean') {
       if (options?.network) {
         abi = await getAbi(options.contractAddress, options.contractName, options.network);

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -434,7 +434,7 @@ export interface ContractCallOptions {
   anchorMode?: AnchorMode;
   postConditionMode?: PostConditionMode;
   postConditions?: PostCondition[];
-  validateWithAbi?: boolean;
+  validateWithAbi?: boolean | ClarityAbi;
 }
 
 /**
@@ -506,12 +506,18 @@ export async function makeContractCall(txOptions: ContractCallOptions): Promise<
   );
 
   if (options?.validateWithAbi) {
-    if (options?.network) {
-      const abi = await getAbi(options.contractAddress, options.contractName, options.network);
-      validateContractCall(payload, abi);
+    let abi;
+    if (typeof options.validateWithAbi === 'boolean') {
+      if (options?.network) {
+        abi = await getAbi(options.contractAddress, options.contractName, options.network);
+      } else {
+        throw new Error('Network option must be provided in order to validate with ABI');
+      }
     } else {
-      throw new Error('Network option must be provided in order to validate with ABI');
+      abi = options.validateWithAbi;
     }
+
+    validateContractCall(payload, abi);
   }
 
   const addressHashMode = AddressHashMode.SerializeP2PKH;

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -173,7 +173,7 @@ export async function getAbi(
       msg = await response.text();
     } catch (error) {}
     throw new Error(
-      `Error fetching ABI. Response ${response.status}: ${response.statusText} fetching ${url} - ${msg}`
+      `Error fetching contract ABI for contract "${contractName}" at address ${address}. Response ${response.status}: ${response.statusText}. Attempted to fetch ${url} and failed with the message: "${msg}"`
     );
   }
 

--- a/src/clarity/clarityValue.ts
+++ b/src/clarity/clarityValue.ts
@@ -44,3 +44,34 @@ export type ClarityValue =
   | ResponseOkCV
   | ListCV
   | TupleCV;
+
+export function getCVTypeString(val: ClarityValue): string {
+  switch (val.type) {
+    case ClarityType.BoolTrue:
+    case ClarityType.BoolFalse:
+      return 'bool';
+    case ClarityType.Int:
+      return 'int128';
+    case ClarityType.UInt:
+      return 'uint128';
+    case ClarityType.Buffer:
+      return `buffer(${val.buffer.length})`;
+    case ClarityType.OptionalNone:
+      return 'optional(none)';
+    case ClarityType.OptionalSome:
+      return `optional(${getCVTypeString(val.value)})`;
+    case ClarityType.ResponseErr:
+      return `responseError(${getCVTypeString(val.value)})`;
+    case ClarityType.ResponseOk:
+      return `responseOk(${getCVTypeString(val.value)})`;
+    case ClarityType.PrincipalStandard:
+    case ClarityType.PrincipalContract:
+      return 'principal';
+    case ClarityType.List:
+      return `list(${getCVTypeString(val.list[0])},${val.list.length})`;
+    case ClarityType.Tuple:
+      return `tuple(${Object.keys(val.data)
+        .map(key => JSON.stringify(key) + ':' + getCVTypeString(val.data[key]))
+        .join(',')})`;
+  }
+}

--- a/src/clarity/index.ts
+++ b/src/clarity/index.ts
@@ -1,4 +1,4 @@
-import { ClarityValue, ClarityType } from './clarityValue';
+import { ClarityValue, ClarityType, getCVTypeString } from './clarityValue';
 import { BooleanCV, TrueCV, FalseCV, trueCV, falseCV } from './types/booleanCV';
 import { IntCV, UIntCV, intCV, uintCV } from './types/intCV';
 import { BufferCV, bufferCV, bufferCVFromString } from './types/bufferCV';
@@ -63,6 +63,7 @@ export {
   contractPrincipalCVFromAddress,
   listCV,
   tupleCV,
+  getCVTypeString,
 };
 
 // Serialization

--- a/src/clarity/serialize.ts
+++ b/src/clarity/serialize.ts
@@ -80,17 +80,11 @@ function serializeTupleCV(cv: TupleCV) {
   length.writeUInt32BE(Object.keys(cv.data).length, 0);
   buffers.push(length);
 
-  const lexicographicOrder = Object.keys(cv.data).sort((a, b) => {
-    const bufA = Buffer.from(a);
-    const bufB = Buffer.from(b);
-    return bufA.compare(bufB);
-  });
-
-  for (const key of lexicographicOrder) {
+  for (const [key, value] of Object.entries(cv.data)) {
     const nameWithLength = createLPString(key);
     buffers.push(serializeLPString(nameWithLength));
 
-    const serializedValue = serializeCV(cv.data[key]);
+    const serializedValue = serializeCV(value);
     buffers.push(serializedValue);
   }
 

--- a/src/clarity/serialize.ts
+++ b/src/clarity/serialize.ts
@@ -80,11 +80,17 @@ function serializeTupleCV(cv: TupleCV) {
   length.writeUInt32BE(Object.keys(cv.data).length, 0);
   buffers.push(length);
 
-  for (const [key, value] of Object.entries(cv.data)) {
+  const lexicographicOrder = Object.keys(cv.data).sort((a, b) => {
+    const bufA = Buffer.from(a);
+    const bufB = Buffer.from(b);
+    return bufA.compare(bufB);
+  });
+
+  for (const key of lexicographicOrder) {
     const nameWithLength = createLPString(key);
     buffers.push(serializeLPString(nameWithLength));
 
-    const serializedValue = serializeCV(value);
+    const serializedValue = serializeCV(cv.data[key]);
     buffers.push(serializedValue);
   }
 

--- a/src/clarity/types/tupleCV.ts
+++ b/src/clarity/types/tupleCV.ts
@@ -1,18 +1,32 @@
 import { ClarityType, ClarityValue } from '../clarityValue';
 import { isClarityName } from '../../utils';
 
+type TupleData = { [key: string]: ClarityValue };
+
 interface TupleCV {
   type: ClarityType.Tuple;
-  data: { [key: string]: ClarityValue };
+  data: TupleData;
 }
 
-function tupleCV(data: { [key: string]: ClarityValue }): TupleCV {
+function tupleCV(data: TupleData): TupleCV {
   for (const key in data) {
     if (!isClarityName(key)) {
       throw new Error(`"${key}" is not a valid Clarity name`);
     }
   }
-  return { type: ClarityType.Tuple, data };
+
+  const ordered: TupleData = {};
+  Object.keys(data)
+    .sort((a, b) => {
+      const bufA = Buffer.from(a);
+      const bufB = Buffer.from(b);
+      return bufA.compare(bufB);
+    })
+    .forEach(key => {
+      ordered[key] = data[key];
+    });
+
+  return { type: ClarityType.Tuple, data: ordered };
 }
 
 export { TupleCV, tupleCV };

--- a/src/clarity/types/tupleCV.ts
+++ b/src/clarity/types/tupleCV.ts
@@ -15,18 +15,7 @@ function tupleCV(data: TupleData): TupleCV {
     }
   }
 
-  const ordered: TupleData = {};
-  Object.keys(data)
-    .sort((a, b) => {
-      const bufA = Buffer.from(a);
-      const bufB = Buffer.from(b);
-      return bufA.compare(bufB);
-    })
-    .forEach(key => {
-      ordered[key] = data[key];
-    });
-
-  return { type: ClarityType.Tuple, data: ordered };
+  return { type: ClarityType.Tuple, data };
 }
 
 export { TupleCV, tupleCV };

--- a/src/contract-abi.ts
+++ b/src/contract-abi.ts
@@ -11,10 +11,7 @@ import {
   falseCV,
   trueCV,
   ClarityType,
-  bufferCVFromString,
-  tupleCV,
   getCVTypeString,
-  listCV,
 } from './clarity';
 import { ContractCallPayload, createContractCallPayload } from './payload';
 
@@ -298,6 +295,7 @@ function matchType(cv: ClarityValue, abiType: ClarityAbiType): boolean {
         }
         return true;
       }
+    default:
       return false;
   }
 }
@@ -310,7 +308,7 @@ export function validateContractCall(payload: ContractCallPayload, abi: ClarityA
 
     if (payload.functionArgs.length !== abiArgs.length) {
       throw new Error(
-        `Clarity function expects ${abiArgs.length} arguments but received ${payload.functionArgs.length}`
+        `Clarity function expects ${abiArgs.length} argument(s) but received ${payload.functionArgs.length}`
       );
     }
 

--- a/src/contract-abi.ts
+++ b/src/contract-abi.ts
@@ -281,15 +281,20 @@ function matchType(cv: ClarityValue, abiType: ClarityAbiType): boolean {
       );
     case ClarityType.Tuple:
       if (union.id == ClarityAbiTypeId.ClarityAbiTypeTuple) {
+        const tuple = _.cloneDeep(cv.data);
         for (let i = 0; i < union.type.tuple.length; i++) {
           const abiTupleEntry = union.type.tuple[i];
-          const abiKey = abiTupleEntry.name;
-          const key = Object.keys(cv.data)[i];
-          if (abiKey !== key) {
-            return false;
-          }
+          const key = abiTupleEntry.name;
+          const val = tuple[key];
 
-          if (!matchType(cv.data[key], abiTupleEntry.type)) {
+          // if key exists in cv tuple, check if its type matches the abi
+          // return false if key doesn't exist
+          if (val) {
+            if (!matchType(val, abiTupleEntry.type)) {
+              return false;
+            }
+            delete tuple[key];
+          } else {
             return false;
           }
         }

--- a/src/contract-abi.ts
+++ b/src/contract-abi.ts
@@ -307,6 +307,14 @@ function matchType(cv: ClarityValue, abiType: ClarityAbiType): boolean {
   }
 }
 
+/**
+ * Validates a contract-call payload with a contract ABI
+ *
+ * @param {ContractCallPayload} payload - a contract-call payload
+ * @param {ClarityAbi} abi - a contract ABI
+ *
+ * @returns {boolean} true if the payloads functionArgs type check against those in the ABI
+ */
 export function validateContractCall(payload: ContractCallPayload, abi: ClarityAbi): boolean {
   const filtered = abi.functions.filter(fn => fn.name === payload.functionName.content);
   if (filtered.length === 1) {

--- a/src/contract-abi.ts
+++ b/src/contract-abi.ts
@@ -325,11 +325,8 @@ export function validateContractCall(payload: ContractCallPayload, abi: ClarityA
 
       if (!matchType(payloadArg, abiArg.type)) {
         throw new Error(
-          `Clarity function \`${
-            payload.functionName.content
-          }\` expects argument ${i} to be of type ${getTypeString(
-            abiArg.type
-          )}, not ${getCVTypeString(payloadArg)}`
+          `Clarity function \`${payload.functionName.content}\` expects argument ${i +
+            1} to be of type ${getTypeString(abiArg.type)}, not ${getCVTypeString(payloadArg)}`
         );
       }
     }

--- a/src/contract-abi.ts
+++ b/src/contract-abi.ts
@@ -340,9 +340,11 @@ export function validateContractCall(payload: ContractCallPayload, abi: ClarityA
     }
 
     return true;
+  } else if (filtered.length === 0) {
+    throw new Error(`ABI doesn't contain a function with the name ${payload.functionName.content}`);
+  } else {
+    throw new Error(
+      `Malformed ABI. Contains multiple functions with the name ${payload.functionName.content}`
+    );
   }
-
-  throw new Error(
-    `Malformed ABI. Contains multiple functions with the name ${payload.functionName.content}`
-  );
 }

--- a/src/contract-abi.ts
+++ b/src/contract-abi.ts
@@ -20,7 +20,9 @@ class NotImplementedError extends Error {
     super(message);
     this.message = message;
     this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
   }
 }
 

--- a/src/contract-abi.ts
+++ b/src/contract-abi.ts
@@ -1,0 +1,338 @@
+import * as _ from 'lodash';
+
+import {
+  ClarityValue,
+  uintCV,
+  intCV,
+  contractPrincipalCV,
+  standardPrincipalCV,
+  noneCV,
+  bufferCV,
+  falseCV,
+  trueCV,
+  ClarityType,
+  bufferCVFromString,
+  tupleCV,
+  getCVTypeString,
+  listCV,
+} from './clarity';
+import { ContractCallPayload, createContractCallPayload } from './payload';
+
+class NotImplementedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.message = message;
+    this.name = this.constructor.name;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+// From https://github.com/blockstack/stacks-blockchain-sidecar/blob/master/src/event-stream/contract-abi.ts
+
+export type ClarityAbiTypeBuffer = { buffer: { length: number } };
+export type ClarityAbiTypeResponse = { response: { ok: ClarityAbiType; error: ClarityAbiType } };
+export type ClarityAbiTypeOptional = { optional: ClarityAbiType };
+export type ClarityAbiTypeTuple = { tuple: { name: string; type: ClarityAbiType }[] };
+export type ClarityAbiTypeList = { list: { type: ClarityAbiType; length: number } };
+
+export type ClarityAbiTypeUInt128 = 'uint128';
+export type ClarityAbiTypeInt128 = 'int128';
+export type ClarityAbiTypeBool = 'bool';
+export type ClarityAbiTypePrincipal = 'principal';
+export type ClarityAbiTypeNone = 'none';
+
+export type ClarityAbiTypePrimitive =
+  | ClarityAbiTypeUInt128
+  | ClarityAbiTypeInt128
+  | ClarityAbiTypeBool
+  | ClarityAbiTypePrincipal
+  | ClarityAbiTypeNone;
+
+export type ClarityAbiType =
+  | ClarityAbiTypePrimitive
+  | ClarityAbiTypeBuffer
+  | ClarityAbiTypeResponse
+  | ClarityAbiTypeOptional
+  | ClarityAbiTypeTuple
+  | ClarityAbiTypeList;
+
+export enum ClarityAbiTypeId {
+  ClarityAbiTypeUInt128 = 1,
+  ClarityAbiTypeInt128 = 2,
+  ClarityAbiTypeBool = 3,
+  ClarityAbiTypePrincipal = 4,
+  ClarityAbiTypeNone = 5,
+  ClarityAbiTypeBuffer = 6,
+  ClarityAbiTypeResponse = 7,
+  ClarityAbiTypeOptional = 8,
+  ClarityAbiTypeTuple = 9,
+  ClarityAbiTypeList = 10,
+}
+
+export const isClarityAbiPrimitive = (val: ClarityAbiType): val is ClarityAbiTypePrimitive =>
+  typeof val === 'string';
+export const isClarityAbiBuffer = (val: ClarityAbiType): val is ClarityAbiTypeBuffer =>
+  (val as ClarityAbiTypeBuffer).buffer !== undefined;
+export const isClarityAbiResponse = (val: ClarityAbiType): val is ClarityAbiTypeResponse =>
+  (val as ClarityAbiTypeResponse).response !== undefined;
+export const isClarityAbiOptional = (val: ClarityAbiType): val is ClarityAbiTypeOptional =>
+  (val as ClarityAbiTypeOptional).optional !== undefined;
+export const isClarityAbiTuple = (val: ClarityAbiType): val is ClarityAbiTypeTuple =>
+  (val as ClarityAbiTypeTuple).tuple !== undefined;
+export const isClarityAbiList = (val: ClarityAbiType): val is ClarityAbiTypeList =>
+  (val as ClarityAbiTypeList).list !== undefined;
+
+export type ClarityAbiTypeUnion =
+  | { id: ClarityAbiTypeId.ClarityAbiTypeUInt128; type: ClarityAbiTypeUInt128 }
+  | { id: ClarityAbiTypeId.ClarityAbiTypeInt128; type: ClarityAbiTypeInt128 }
+  | { id: ClarityAbiTypeId.ClarityAbiTypeBool; type: ClarityAbiTypeBool }
+  | { id: ClarityAbiTypeId.ClarityAbiTypePrincipal; type: ClarityAbiTypePrincipal }
+  | { id: ClarityAbiTypeId.ClarityAbiTypeNone; type: ClarityAbiTypeNone }
+  | { id: ClarityAbiTypeId.ClarityAbiTypeBuffer; type: ClarityAbiTypeBuffer }
+  | { id: ClarityAbiTypeId.ClarityAbiTypeResponse; type: ClarityAbiTypeResponse }
+  | { id: ClarityAbiTypeId.ClarityAbiTypeOptional; type: ClarityAbiTypeOptional }
+  | { id: ClarityAbiTypeId.ClarityAbiTypeTuple; type: ClarityAbiTypeTuple }
+  | { id: ClarityAbiTypeId.ClarityAbiTypeList; type: ClarityAbiTypeList };
+
+export function getTypeUnion(val: ClarityAbiType): ClarityAbiTypeUnion {
+  if (isClarityAbiPrimitive(val)) {
+    if (val === 'uint128') {
+      return { id: ClarityAbiTypeId.ClarityAbiTypeUInt128, type: val };
+    } else if (val === 'int128') {
+      return { id: ClarityAbiTypeId.ClarityAbiTypeInt128, type: val };
+    } else if (val === 'bool') {
+      return { id: ClarityAbiTypeId.ClarityAbiTypeBool, type: val };
+    } else if (val === 'principal') {
+      return { id: ClarityAbiTypeId.ClarityAbiTypePrincipal, type: val };
+    } else if (val === 'none') {
+      return { id: ClarityAbiTypeId.ClarityAbiTypeNone, type: val };
+    } else {
+      throw new Error(`Unexpected Clarity ABI type primitive: ${JSON.stringify(val)}`);
+    }
+  } else if (isClarityAbiBuffer(val)) {
+    return { id: ClarityAbiTypeId.ClarityAbiTypeBuffer, type: val };
+  } else if (isClarityAbiResponse(val)) {
+    return { id: ClarityAbiTypeId.ClarityAbiTypeResponse, type: val };
+  } else if (isClarityAbiOptional(val)) {
+    return { id: ClarityAbiTypeId.ClarityAbiTypeOptional, type: val };
+  } else if (isClarityAbiTuple(val)) {
+    return { id: ClarityAbiTypeId.ClarityAbiTypeTuple, type: val };
+  } else if (isClarityAbiList(val)) {
+    return { id: ClarityAbiTypeId.ClarityAbiTypeList, type: val };
+  } else {
+    throw new Error(`Unexpected Clarity ABI type: ${JSON.stringify(val)}`);
+  }
+}
+
+function encodeClarityValue(type: ClarityAbiType, val: string): ClarityValue;
+function encodeClarityValue(type: ClarityAbiTypeUnion, val: string): ClarityValue;
+function encodeClarityValue(
+  input: ClarityAbiTypeUnion | ClarityAbiType,
+  val: string
+): ClarityValue {
+  let union: ClarityAbiTypeUnion;
+  if ((input as ClarityAbiTypeUnion).id !== undefined) {
+    union = input as ClarityAbiTypeUnion;
+  } else {
+    union = getTypeUnion(input as ClarityAbiType);
+  }
+  switch (union.id) {
+    case ClarityAbiTypeId.ClarityAbiTypeUInt128:
+      return uintCV(val);
+    case ClarityAbiTypeId.ClarityAbiTypeInt128:
+      return intCV(val);
+    case ClarityAbiTypeId.ClarityAbiTypeBool:
+      if (val === 'false' || val === '0') return falseCV();
+      else if (val === 'true' || val === '1') return trueCV();
+      else throw new Error(`Unexpected Clarity bool value: ${JSON.stringify(val)}`);
+    case ClarityAbiTypeId.ClarityAbiTypePrincipal:
+      if (val.includes('.')) {
+        const [addr, name] = val.split('.');
+        return contractPrincipalCV(addr, name);
+      } else {
+        return standardPrincipalCV(val);
+      }
+    case ClarityAbiTypeId.ClarityAbiTypeNone:
+      return noneCV();
+    case ClarityAbiTypeId.ClarityAbiTypeBuffer:
+      return bufferCV(Buffer.from(val, 'utf8'));
+    case ClarityAbiTypeId.ClarityAbiTypeResponse:
+      throw new NotImplementedError(`Unsupported encoding for Clarity type: ${union.id}`);
+    case ClarityAbiTypeId.ClarityAbiTypeOptional:
+      throw new NotImplementedError(`Unsupported encoding for Clarity type: ${union.id}`);
+    case ClarityAbiTypeId.ClarityAbiTypeTuple:
+      throw new NotImplementedError(`Unsupported encoding for Clarity type: ${union.id}`);
+    case ClarityAbiTypeId.ClarityAbiTypeList:
+      throw new NotImplementedError(`Unsupported encoding for Clarity type: ${union.id}`);
+    default:
+      throw new Error(`Unexpected Clarity type ID: ${JSON.stringify(union)}`);
+  }
+}
+export { encodeClarityValue };
+
+export function getTypeString(val: ClarityAbiType): string {
+  if (isClarityAbiPrimitive(val)) {
+    return val;
+  } else if (isClarityAbiBuffer(val)) {
+    return `buffer(${val.buffer.length})`;
+  } else if (isClarityAbiResponse(val)) {
+    return `response(${getTypeString(val.response.ok)},${getTypeString(val.response.error)})`;
+  } else if (isClarityAbiOptional(val)) {
+    return `optional(${getTypeString(val.optional)})`;
+  } else if (isClarityAbiTuple(val)) {
+    return `tuple(${val.tuple
+      .map(t => JSON.stringify(t.name) + ':' + getTypeString(t.type))
+      .join(',')})`;
+  } else if (isClarityAbiList(val)) {
+    return `list(${getTypeString(val.list.type)},${val.list.length})`;
+  } else {
+    throw new Error(`Type string unsupported for Clarity type: ${JSON.stringify(val)}`);
+  }
+}
+
+export interface ClarityAbiFunction {
+  name: string;
+  access: 'private' | 'public' | 'read_only';
+  args: {
+    name: string;
+    type: ClarityAbiType;
+  }[];
+  outputs: {
+    type: ClarityAbiType;
+  };
+}
+
+export interface ClarityAbiVariable {
+  name: string;
+  access: 'variable' | 'constant';
+  type: ClarityAbiType;
+}
+
+export interface ClarityAbiMap {
+  name: string;
+  key: {
+    name: string;
+    type: ClarityAbiType;
+  }[];
+  value: {
+    name: string;
+    type: ClarityAbiType;
+  }[];
+}
+
+export interface ClarityAbiTypeFungibleToken {
+  name: string;
+}
+
+export interface ClarityAbiTypeNonFungibleToken {
+  name: string;
+  type: ClarityAbiType;
+}
+
+export interface ClarityAbi {
+  functions: ClarityAbiFunction[];
+  variables: ClarityAbiVariable[];
+  maps: ClarityAbiMap[];
+  fungible_tokens: ClarityAbiTypeFungibleToken[];
+  non_fungible_tokens: ClarityAbiTypeNonFungibleToken[];
+}
+
+function matchType(cv: ClarityValue, abiType: ClarityAbiType): boolean {
+  const union = getTypeUnion(abiType);
+
+  switch (cv.type) {
+    case ClarityType.BoolTrue:
+    case ClarityType.BoolFalse:
+      return union.id === ClarityAbiTypeId.ClarityAbiTypeBool;
+    case ClarityType.Int:
+      return union.id === ClarityAbiTypeId.ClarityAbiTypeInt128;
+    case ClarityType.UInt:
+      return union.id === ClarityAbiTypeId.ClarityAbiTypeUInt128;
+    case ClarityType.Buffer:
+      return (
+        union.id === ClarityAbiTypeId.ClarityAbiTypeBuffer &&
+        union.type.buffer.length === cv.buffer.length
+      );
+    case ClarityType.OptionalNone:
+      return (
+        union.id === ClarityAbiTypeId.ClarityAbiTypeNone ||
+        union.id === ClarityAbiTypeId.ClarityAbiTypeOptional
+      );
+    case ClarityType.OptionalSome:
+      return (
+        union.id === ClarityAbiTypeId.ClarityAbiTypeOptional &&
+        matchType(cv.value, union.type.optional)
+      );
+    case ClarityType.ResponseErr:
+      return (
+        union.id === ClarityAbiTypeId.ClarityAbiTypeResponse &&
+        matchType(cv.value, union.type.response.error)
+      );
+    case ClarityType.ResponseOk:
+      return (
+        union.id === ClarityAbiTypeId.ClarityAbiTypeResponse &&
+        matchType(cv.value, union.type.response.ok)
+      );
+    case ClarityType.PrincipalContract:
+    case ClarityType.PrincipalStandard:
+      return union.id === ClarityAbiTypeId.ClarityAbiTypePrincipal;
+    case ClarityType.List:
+      return (
+        union.id == ClarityAbiTypeId.ClarityAbiTypeList &&
+        union.type.list.length === cv.list.length &&
+        _.every(cv.list, val => matchType(val, union.type.list.type))
+      );
+    case ClarityType.Tuple:
+      if (union.id == ClarityAbiTypeId.ClarityAbiTypeTuple) {
+        for (let i = 0; i < union.type.tuple.length; i++) {
+          const abiTupleEntry = union.type.tuple[i];
+          const abiKey = abiTupleEntry.name;
+          const key = Object.keys(cv.data)[i];
+          if (abiKey !== key) {
+            return false;
+          }
+
+          if (!matchType(cv.data[key], abiTupleEntry.type)) {
+            return false;
+          }
+        }
+        return true;
+      }
+      return false;
+  }
+}
+
+export function validateContractCall(payload: ContractCallPayload, abi: ClarityAbi): boolean {
+  const filtered = abi.functions.filter(fn => fn.name === payload.functionName.content);
+  if (filtered.length === 1) {
+    const abiFunc = filtered[0];
+    const abiArgs = abiFunc.args;
+
+    if (payload.functionArgs.length !== abiArgs.length) {
+      throw new Error(
+        `Clarity function expects ${abiArgs.length} arguments but received ${payload.functionArgs.length}`
+      );
+    }
+
+    for (let i = 0; i < payload.functionArgs.length; i++) {
+      const payloadArg = payload.functionArgs[i];
+      const abiArg = abiArgs[i];
+
+      if (!matchType(payloadArg, abiArg.type)) {
+        throw new Error(
+          `Clarity function \`${
+            payload.functionName.content
+          }\` expects argument ${i} to be of type ${getTypeString(
+            abiArg.type
+          )}, not ${getCVTypeString(payloadArg)}`
+        );
+      }
+    }
+
+    return true;
+  }
+
+  throw new Error(
+    `Malformed ABI. Contains multiple functions with the name ${payload.functionName.content}`
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,3 +63,4 @@ export * from './builders';
 export * from './network';
 export * from './types';
 export * from './constants';
+export * from './contract-abi';

--- a/src/network.ts
+++ b/src/network.ts
@@ -1,4 +1,5 @@
 import { TransactionVersion, ChainID } from './constants';
+import { Address, addressToString } from './types';
 
 export interface StacksNetwork {
   version: TransactionVersion;
@@ -7,6 +8,7 @@ export interface StacksNetwork {
   broadcastApiUrl: string;
   transferFeeEstimateApiUrl: string;
   balanceApiUrl: string;
+  getAbiApiUrl: (address: string, contract: string) => string;
 }
 
 export class StacksMainnet implements StacksNetwork {
@@ -16,6 +18,8 @@ export class StacksMainnet implements StacksNetwork {
   broadcastApiUrl = `${this.coreApiUrl}/v2/transactions`;
   transferFeeEstimateApiUrl = `${this.coreApiUrl}/v2/fees/transfer`;
   balanceApiUrl = `${this.coreApiUrl}/v2/accounts`;
+  getAbiApiUrl = (address: string, contract: string) =>
+    `${this.coreApiUrl}/v2/contracts/interface/${address}/${contract}`;
 }
 
 export class StacksTestnet implements StacksNetwork {
@@ -25,4 +29,6 @@ export class StacksTestnet implements StacksNetwork {
   broadcastApiUrl = `${this.coreApiUrl}/v2/transactions`;
   transferFeeEstimateApiUrl = `${this.coreApiUrl}/v2/fees/transfer`;
   balanceApiUrl = `${this.coreApiUrl}/v2/accounts`;
+  getAbiApiUrl = (address: string, contract: string) =>
+    `${this.coreApiUrl}/v2/contracts/interface/${address}/${contract}`;
 }

--- a/src/network.ts
+++ b/src/network.ts
@@ -1,13 +1,16 @@
 import { TransactionVersion, ChainID } from './constants';
-import { Address, addressToString } from './types';
 
 export interface StacksNetwork {
   version: TransactionVersion;
   chainId: ChainID;
   coreApiUrl: string;
-  broadcastApiUrl: string;
-  transferFeeEstimateApiUrl: string;
-  balanceApiUrl: string;
+  broadcastEndpoint: string;
+  transferFeeEstimateEndpoint: string;
+  accountEndpoint: string;
+  contractAbiEndpoint: string;
+  getBroadcastApiUrl: () => string;
+  getTransferFeeEstimateApiUrl: () => string;
+  getAccountApiUrl: (address: string) => string;
   getAbiApiUrl: (address: string, contract: string) => string;
 }
 
@@ -15,20 +18,20 @@ export class StacksMainnet implements StacksNetwork {
   version = TransactionVersion.Mainnet;
   chainId = ChainID.Mainnet;
   coreApiUrl = 'https://core.blockstack.org';
-  broadcastApiUrl = `${this.coreApiUrl}/v2/transactions`;
-  transferFeeEstimateApiUrl = `${this.coreApiUrl}/v2/fees/transfer`;
-  balanceApiUrl = `${this.coreApiUrl}/v2/accounts`;
+  broadcastEndpoint = '/v2/transactions';
+  transferFeeEstimateEndpoint = '/v2/fees/transfer';
+  accountEndpoint = '/v2/accounts';
+  contractAbiEndpoint = '/v2/contracts/interface';
+  getBroadcastApiUrl = () => `${this.coreApiUrl}${this.broadcastEndpoint}`;
+  getTransferFeeEstimateApiUrl = () => `${this.coreApiUrl}${this.transferFeeEstimateEndpoint}`;
+  getAccountApiUrl = (address: string) =>
+    `${this.coreApiUrl}${this.accountEndpoint}/${address}?proof=0`;
   getAbiApiUrl = (address: string, contract: string) =>
-    `${this.coreApiUrl}/v2/contracts/interface/${address}/${contract}`;
+    `${this.coreApiUrl}${this.contractAbiEndpoint}/${address}/${contract}`;
 }
 
-export class StacksTestnet implements StacksNetwork {
+export class StacksTestnet extends StacksMainnet implements StacksNetwork {
   version = TransactionVersion.Testnet;
   chainId = ChainID.Testnet;
   coreApiUrl = 'http://neon.blockstack.org:20443';
-  broadcastApiUrl = `${this.coreApiUrl}/v2/transactions`;
-  transferFeeEstimateApiUrl = `${this.coreApiUrl}/v2/fees/transfer`;
-  balanceApiUrl = `${this.coreApiUrl}/v2/accounts`;
-  getAbiApiUrl = (address: string, contract: string) =>
-    `${this.coreApiUrl}/v2/contracts/interface/${address}/${contract}`;
 }

--- a/tests/src/abi-tests.ts
+++ b/tests/src/abi-tests.ts
@@ -13,7 +13,6 @@ import {
   responseOkCV,
   responseErrorCV,
   noneCV,
-  ClarityValue,
 } from '../../src';
 import { validateContractCall, ClarityAbi } from '../../src/contract-abi';
 
@@ -73,7 +72,27 @@ test('ABI validation fail, tuple mistyped', () => {
   );
 
   expect(() => validateContractCall(payload, TEST_ABI)).toThrow(
-    'Clarity function `tuple-test` expects argument 0 to be of type tuple("key1":bool,"key2":int128,"key3":uint128,"key4":principal,"key5":buffer(3),"key6":optional(bool),"key7":response(bool,bool),"key8":list(bool,2))'
+    // prettier-ignore
+    'Clarity function `tuple-test` expects argument 1 to be of type ' +
+      'tuple(' +
+        '"key1":bool,' +
+        '"key2":int128,' +
+        '"key3":uint128,' +
+        '"key4":principal,' +
+        '"key5":buffer(3),' +
+        '"key6":optional(bool),' +
+        '"key7":response(bool,bool),' +
+        '"key8":list(bool,2)), ' +
+      'not ' +
+      'tuple(' +
+        '"key1":bool,' +
+        '"key2":int128,' +
+        '"key3":uint128,' +
+        '"key4":principal,' +
+        '"key5":buffer(3),' +
+        '"key6":optional(none),' +
+        '"key7":responseError(bool),' +
+        '"key8":bool)'
   );
 });
 
@@ -102,7 +121,26 @@ test('ABI validation fail, tuple wrong key', () => {
   );
 
   expect(() => validateContractCall(payload, TEST_ABI)).toThrow(
-    'Clarity function `tuple-test` expects argument 0 to be of type tuple("key1":bool,"key2":int128,"key3":uint128,"key4":principal,"key5":buffer(3),"key6":optional(bool),"key7":response(bool,bool),"key8":list(bool,2))'
+    // prettier-ignore
+    'Clarity function `tuple-test` expects argument 1 to be of type ' +
+      'tuple(' +
+        '"key1":bool,' +
+        '"key2":int128,' +
+        '"key3":uint128,' +
+        '"key4":principal,' +
+        '"key5":buffer(3),' +
+        '"key6":optional(bool),' +
+        '"key7":response(bool,bool),' +
+        '"key8":list(bool,2)), ' +
+      'not ' +
+      'tuple("wrong-key":bool,' +
+        '"key2":int128,' +
+        '"key3":uint128,' +
+        '"key4":principal,' +
+        '"key5":buffer(3),' +
+        '"key6":optional(bool),' +
+        '"key7":responseOk(bool),' +
+        '"key9":list(bool,2))'
   );
 });
 

--- a/tests/src/abi-tests.ts
+++ b/tests/src/abi-tests.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import { readFileSync } from 'fs';
 import { createContractCallPayload } from '../../src/payload';
 import {
   trueCV,
@@ -16,9 +16,7 @@ import {
 } from '../../src';
 import { validateContractCall, ClarityAbi } from '../../src/contract-abi';
 
-const TEST_ABI: ClarityAbi = JSON.parse(
-  fs.readFileSync('./tests/src/abi/test-abi.json').toString()
-);
+const TEST_ABI: ClarityAbi = JSON.parse(readFileSync('./tests/src/abi/test-abi.json').toString());
 
 test('ABI validation', () => {
   const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';

--- a/tests/src/abi-tests.ts
+++ b/tests/src/abi-tests.ts
@@ -10,6 +10,10 @@ import {
   someCV,
   falseCV,
   listCV,
+  responseOkCV,
+  responseErrorCV,
+  noneCV,
+  ClarityValue,
 } from '../../src';
 import { validateContractCall, ClarityAbi } from '../../src/contract-abi';
 
@@ -29,7 +33,8 @@ test('ABI validation', () => {
       key4: standardPrincipalCV('SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B'),
       key5: bufferCVFromString('foo'),
       key6: someCV(falseCV()),
-      key7: listCV([trueCV(), falseCV()]),
+      key7: responseOkCV(trueCV()),
+      key8: listCV([trueCV(), falseCV()]),
     }),
   ];
 
@@ -43,19 +48,20 @@ test('ABI validation', () => {
   validateContractCall(payload, TEST_ABI);
 });
 
-test('ABI validation fail', () => {
+test('ABI validation fail, tuple mistyped', () => {
   const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
   const contractName = 'test';
   const functionName = 'tuple-test';
   const functionArgs = [
     tupleCV({
-      key1: intCV(1),
+      key1: trueCV(),
       key2: intCV(-1),
       key3: uintCV(1),
       key4: standardPrincipalCV('SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B'),
       key5: bufferCVFromString('foo'),
-      key6: someCV(falseCV()),
-      key7: listCV([trueCV(), falseCV()]),
+      key6: noneCV(),
+      key7: responseErrorCV(trueCV()),
+      key8: falseCV(),
     }),
   ];
 
@@ -67,6 +73,53 @@ test('ABI validation fail', () => {
   );
 
   expect(() => validateContractCall(payload, TEST_ABI)).toThrow(
-    'Clarity function `tuple-test` expects argument 0 to be of type tuple("key1":bool,"key2":int128,"key3":uint128,"key4":principal,"key5":buffer(3),"key6":optional(bool),"key7":list(bool,2)), not tuple("key1":int128,"key2":int128,"key3":uint128,"key4":principal,"key5":buffer(3),"key6":optional(bool),"key7":list(bool,2))'
+    'Clarity function `tuple-test` expects argument 0 to be of type tuple("key1":bool,"key2":int128,"key3":uint128,"key4":principal,"key5":buffer(3),"key6":optional(bool),"key7":response(bool,bool),"key8":list(bool,2))'
+  );
+});
+
+test('ABI validation fail, tuple wrong key', () => {
+  const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'kv-store';
+  const functionName = 'tuple-test';
+  const functionArgs = [
+    tupleCV({
+      'wrong-key': trueCV(),
+      key2: intCV(-1),
+      key3: uintCV(1),
+      key4: standardPrincipalCV('SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B'),
+      key5: bufferCVFromString('foo'),
+      key6: someCV(falseCV()),
+      key7: responseOkCV(trueCV()),
+      key9: listCV([trueCV(), falseCV()]),
+    }),
+  ];
+
+  const payload = createContractCallPayload(
+    contractAddress,
+    contractName,
+    functionName,
+    functionArgs
+  );
+
+  expect(() => validateContractCall(payload, TEST_ABI)).toThrow(
+    'Clarity function `tuple-test` expects argument 0 to be of type tuple("key1":bool,"key2":int128,"key3":uint128,"key4":principal,"key5":buffer(3),"key6":optional(bool),"key7":response(bool,bool),"key8":list(bool,2))'
+  );
+});
+
+test('ABI validation fail, wrong number of args', () => {
+  const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'kv-store';
+  const functionName = 'tuple-test';
+  const functionArgs = [trueCV(), falseCV()];
+
+  const payload = createContractCallPayload(
+    contractAddress,
+    contractName,
+    functionName,
+    functionArgs
+  );
+
+  expect(() => validateContractCall(payload, TEST_ABI)).toThrow(
+    'Clarity function expects 1 argument(s) but received 2'
   );
 });

--- a/tests/src/abi-tests.ts
+++ b/tests/src/abi-tests.ts
@@ -159,3 +159,64 @@ test('ABI validation fail, wrong number of args', () => {
     'Clarity function expects 1 argument(s) but received 2'
   );
 });
+
+test('Validation fails when ABI has multiple functions with the same nam', () => {
+  const abi: ClarityAbi = {
+    functions: [
+      {
+        name: 'get-value',
+        access: 'public',
+        args: [{ name: 'key', type: { buffer: { length: 3 } } }],
+        outputs: {
+          type: { response: { ok: { buffer: { length: 3 } }, error: 'int128' } },
+        },
+      },
+      {
+        name: 'get-value',
+        access: 'public',
+        args: [{ name: 'key', type: { buffer: { length: 3 } } }],
+        outputs: {
+          type: { response: { ok: { buffer: { length: 3 } }, error: 'int128' } },
+        },
+      },
+    ],
+    variables: [],
+    maps: [],
+    fungible_tokens: [],
+    non_fungible_tokens: [],
+  };
+
+  const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'kv-store';
+  const functionName = 'get-value';
+  const functionArgs = [trueCV(), falseCV()];
+
+  const payload = createContractCallPayload(
+    contractAddress,
+    contractName,
+    functionName,
+    functionArgs
+  );
+
+  expect(() => validateContractCall(payload, abi)).toThrow(
+    'Malformed ABI. Contains multiple functions with the name get-value'
+  );
+});
+
+test('Validation fails when abi is missing specified function', () => {
+  const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'kv-store';
+  const functionName = 'get-value';
+  const functionArgs = [trueCV(), falseCV()];
+
+  const payload = createContractCallPayload(
+    contractAddress,
+    contractName,
+    functionName,
+    functionArgs
+  );
+
+  expect(() => validateContractCall(payload, TEST_ABI)).toThrow(
+    "ABI doesn't contain a function with the name get-value"
+  );
+});

--- a/tests/src/abi-tests.ts
+++ b/tests/src/abi-tests.ts
@@ -1,0 +1,72 @@
+import * as fs from 'fs';
+import { createContractCallPayload } from '../../src/payload';
+import {
+  trueCV,
+  intCV,
+  tupleCV,
+  uintCV,
+  standardPrincipalCV,
+  bufferCVFromString,
+  someCV,
+  falseCV,
+  listCV,
+} from '../../src';
+import { validateContractCall, ClarityAbi } from '../../src/contract-abi';
+
+const TEST_ABI: ClarityAbi = JSON.parse(
+  fs.readFileSync('./tests/src/abi/test-abi.json').toString()
+);
+
+test('ABI validation', () => {
+  const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'test';
+  const functionName = 'tuple-test';
+  const functionArgs = [
+    tupleCV({
+      key1: trueCV(),
+      key2: intCV(-1),
+      key3: uintCV(1),
+      key4: standardPrincipalCV('SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B'),
+      key5: bufferCVFromString('foo'),
+      key6: someCV(falseCV()),
+      key7: listCV([trueCV(), falseCV()]),
+    }),
+  ];
+
+  const payload = createContractCallPayload(
+    contractAddress,
+    contractName,
+    functionName,
+    functionArgs
+  );
+
+  validateContractCall(payload, TEST_ABI);
+});
+
+test('ABI validation fail', () => {
+  const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'test';
+  const functionName = 'tuple-test';
+  const functionArgs = [
+    tupleCV({
+      key1: intCV(1),
+      key2: intCV(-1),
+      key3: uintCV(1),
+      key4: standardPrincipalCV('SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B'),
+      key5: bufferCVFromString('foo'),
+      key6: someCV(falseCV()),
+      key7: listCV([trueCV(), falseCV()]),
+    }),
+  ];
+
+  const payload = createContractCallPayload(
+    contractAddress,
+    contractName,
+    functionName,
+    functionArgs
+  );
+
+  expect(() => validateContractCall(payload, TEST_ABI)).toThrow(
+    'Clarity function `tuple-test` expects argument 0 to be of type tuple("key1":bool,"key2":int128,"key3":uint128,"key4":principal,"key5":buffer(3),"key6":optional(bool),"key7":list(bool,2)), not tuple("key1":int128,"key2":int128,"key3":uint128,"key4":principal,"key5":buffer(3),"key6":optional(bool),"key7":list(bool,2))'
+  );
+});

--- a/tests/src/abi/kv-store-abi.json
+++ b/tests/src/abi/kv-store-abi.json
@@ -1,0 +1,31 @@
+{
+  "functions": [
+    {
+      "name": "get-value",
+      "access": "public",
+      "args": [{ "name": "key", "type": { "buffer": { "length": 3 } } }],
+      "outputs": {
+        "type": { "response": { "ok": { "buffer": { "length": 3 } }, "error": "int128" } }
+      }
+    },
+    {
+      "name": "set-value",
+      "access": "public",
+      "args": [
+        { "name": "key", "type": { "buffer": { "length": 3 } } },
+        { "name": "value", "type": { "buffer": { "length": 3 } } }
+      ],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "none" } } }
+    }
+  ],
+  "variables": [],
+  "maps": [
+    {
+      "name": "store",
+      "key": [{ "name": "key", "type": { "buffer": { "length": 3 } } }],
+      "value": [{ "name": "value", "type": { "buffer": { "length": 3 } } }]
+    }
+  ],
+  "fungible_tokens": [],
+  "non_fungible_tokens": []
+}

--- a/tests/src/abi/test-abi.json
+++ b/tests/src/abi/test-abi.json
@@ -11,7 +11,8 @@
           { "name": "key4", "type": "principal" },
           { "name": "key5", "type": { "buffer": { "length": 3 } } },
           { "name": "key6", "type": { "optional": "bool" } },
-          { "name": "key7", "type": { "list": { "type": "bool", "length": 2 } } }
+          { "name": "key7", "type": { "response": { "ok": "bool", "error": "bool" } } },
+          { "name": "key8", "type": { "list": { "type": "bool", "length": 2 } } }
         ]}}
       ],
       "outputs": { "type": { "response": { "ok": "bool", "error": "none" } } }

--- a/tests/src/abi/test-abi.json
+++ b/tests/src/abi/test-abi.json
@@ -1,0 +1,24 @@
+{
+  "functions": [
+    {
+      "name": "tuple-test",
+      "access": "public",
+      "args": [
+        { "name": "arg1", "type": { "tuple": [
+          { "name": "key1", "type": "bool" },
+          { "name": "key2", "type": "int128" },
+          { "name": "key3", "type": "uint128" },
+          { "name": "key4", "type": "principal" },
+          { "name": "key5", "type": { "buffer": { "length": 3 } } },
+          { "name": "key6", "type": { "optional": "bool" } },
+          { "name": "key7", "type": { "list": { "type": "bool", "length": 2 } } }
+        ]}}
+      ],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "none" } } }
+    }
+  ],
+  "variables": [],
+  "maps": [],
+  "fungible_tokens": [],
+  "non_fungible_tokens": []
+}

--- a/tests/src/builder-tests.ts
+++ b/tests/src/builder-tests.ts
@@ -459,7 +459,7 @@ test('Transaction broadcast', async () => {
   expect(fetchMock.mock.calls[0][1]?.body).toEqual(transaction.serialize());
 });
 
-test('Make contract-call ABI validation', async () => {
+test('Make contract-call with network ABI validation', async () => {
   const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
   const contractName = 'kv-store';
   const functionName = 'get-value';
@@ -488,4 +488,30 @@ test('Make contract-call ABI validation', async () => {
 
   expect(fetchMock.mock.calls.length).toEqual(1);
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getAbiApiUrl(contractAddress, contractName));
+});
+
+test('Make contract-call with provided ABI validation', async () => {
+  const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'kv-store';
+  const functionName = 'get-value';
+  const buffer = bufferCV(Buffer.from('foo'));
+  const senderKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
+
+  const fee = new BigNum(0);
+
+  const abi: ClarityAbi = JSON.parse(
+    fs.readFileSync('./tests/src/abi/kv-store-abi.json').toString()
+  );
+
+  const transaction = await makeContractCall({
+    contractAddress,
+    contractName,
+    functionName,
+    senderKey,
+    functionArgs: [buffer],
+    fee,
+    nonce: new BigNum(1),
+    validateWithAbi: abi,
+    postConditionMode: PostConditionMode.Allow,
+  });
 });

--- a/tests/src/builder-tests.ts
+++ b/tests/src/builder-tests.ts
@@ -464,7 +464,7 @@ test('Make contract-call ABI validation', async () => {
   const contractName = 'kv-store';
   const functionName = 'get-value';
   const buffer = bufferCV(Buffer.from('foo'));
-  const secretKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
+  const senderKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
 
   const fee = new BigNum(0);
 
@@ -473,20 +473,18 @@ test('Make contract-call ABI validation', async () => {
   const abi = fs.readFileSync('./tests/src/abi/kv-store-abi.json').toString();
   fetchMock.mockOnce(abi);
 
-  const transaction = await makeContractCall(
+  const transaction = await makeContractCall({
     contractAddress,
     contractName,
     functionName,
-    [buffer],
-    secretKey,
-    {
-      fee,
-      nonce: new BigNum(1),
-      network: new StacksTestnet(),
-      validateWithAbi: true,
-      postConditionMode: PostConditionMode.Allow,
-    }
-  );
+    senderKey,
+    functionArgs: [buffer],
+    fee,
+    nonce: new BigNum(1),
+    network: new StacksTestnet(),
+    validateWithAbi: true,
+    postConditionMode: PostConditionMode.Allow,
+  });
 
   expect(fetchMock.mock.calls.length).toEqual(1);
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getAbiApiUrl(contractAddress, contractName));

--- a/tests/src/builder-tests.ts
+++ b/tests/src/builder-tests.ts
@@ -393,7 +393,7 @@ test('Estimate token transfer fee', async () => {
 
   expect(fetchMock.mock.calls.length).toEqual(2);
   expect(fetchMock.mock.calls[0][0]).toEqual(apiUrl);
-  expect(fetchMock.mock.calls[1][0]).toEqual(network.transferFeeEstimateApiUrl);
+  expect(fetchMock.mock.calls[1][0]).toEqual(network.getTransferFeeEstimateApiUrl());
   expect(resultEstimateFee.toNumber()).toEqual(estimateFee.toNumber());
   expect(resultEstimateFee2.toNumber()).toEqual(estimateFee.toNumber());
 });
@@ -407,7 +407,7 @@ test('Make STX token transfer with fetch account nonce', async () => {
   const senderAddress = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
   const memo = 'test memo';
   const network = new StacksTestnet();
-  const apiUrl = `${network.balanceApiUrl}/${senderAddress}?proof=0`;
+  const apiUrl = network.getAccountApiUrl(senderAddress);
 
   fetchMock.mockOnce(`{"balance":"0", "nonce":${nonce}}`);
 
@@ -455,7 +455,7 @@ test('Transaction broadcast', async () => {
   broadcastTransaction(transaction, network);
 
   expect(fetchMock.mock.calls.length).toEqual(1);
-  expect(fetchMock.mock.calls[0][0]).toEqual(network.broadcastApiUrl);
+  expect(fetchMock.mock.calls[0][0]).toEqual(network.getBroadcastApiUrl());
   expect(fetchMock.mock.calls[0][1]?.body).toEqual(transaction.serialize());
 });
 


### PR DESCRIPTION
## Description

This PR augments the `makeContractCall` transaction builder such that it fetches the contracts ABI (either from the mainne or testnet) and uses the ABI to validate that the `contract-call` payload's function arguments match the contract specification.

Issue: #3 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
