### PR TITLE
Helper functions for AddressFromPrivateKey and AddressFromPublicKey

### DIFF
--- a/tests/src/keys-tests.ts
+++ b/tests/src/keys-tests.ts
@@ -6,10 +6,12 @@ import {
   createStacksPrivateKey,
   getPublicKey,
   privateKeyToString,
+  getAddressFromPrivateKey,
+  getAddressFromPublicKey,
 } from '../../src/keys';
 
 import { serializeDeserialize } from './macros';
-import { StacksMessageType } from '../../src/constants';
+import { StacksMessageType, TransactionVersion } from '../../src/constants';
 
 test('Stacks public key and private keys', () => {
   const privKeyString = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc';
@@ -27,4 +29,28 @@ test('Stacks public key and private keys', () => {
 
   const randomKey = makeRandomPrivKey();
   expect(privateKeyToString(randomKey).length).toEqual(64);
+
+  expect(getAddressFromPrivateKey(privKeyString)).toBe('SPZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZEA9PX5');
+  expect(getAddressFromPrivateKey(Buffer.from(privKeyString, 'hex'))).toBe(
+    'SPZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZEA9PX5'
+  );
+
+  expect(getAddressFromPrivateKey(privKeyString, TransactionVersion.Testnet)).toBe(
+    'STZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZG8ZXFM'
+  );
+  expect(
+    getAddressFromPrivateKey(Buffer.from(privKeyString, 'hex'), TransactionVersion.Testnet)
+  ).toBe('STZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZG8ZXFM');
+
+  expect(getAddressFromPublicKey(pubKeyString)).toBe('SPZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZEA9PX5');
+  expect(getAddressFromPublicKey(Buffer.from(pubKeyString, 'hex'))).toBe(
+    'SPZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZEA9PX5'
+  );
+
+  expect(getAddressFromPublicKey(pubKeyString, TransactionVersion.Testnet)).toBe(
+    'STZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZG8ZXFM'
+  );
+  expect(
+    getAddressFromPublicKey(Buffer.from(pubKeyString, 'hex'), TransactionVersion.Testnet)
+  ).toBe('STZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZG8ZXFM');
 });


### PR DESCRIPTION
## Description

Creating an address from a public or private key typically involved code like:
```ts
  function getAddressFromPrivateKey(privateKey: string): string {
    const addrVer = addressHashModeToVersion(
      AddressHashMode.SerializeP2PKH,
      TransactionVersion.Testnet
    );
    const pubKey = pubKeyfromPrivKey(privateKey);
    const addr = addressFromPublicKeys(addrVer, AddressHashMode.SerializeP2PKH, 1, [pubKey]);
    const addrString = addressToString(addr);
    return addrString;
  }
```

Helper functions are implemented so this can be done with:
```ts
getAddressFromPrivateKey(privateKey, TransactionVersion.Testnet);
```

For details refer to issue #123

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

Provide context on how tests should be performed.

1. Is testing required for this change?
2. If it’s a bug fix, list steps to reproduce the bug
3. Briefly mention affected code paths
4. List other affected projects if possible
5. Things to watch out for when testing

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
