### PR TITLE
Clarity Value toString function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - ABI validation for contract-call transactions
 - Additional methods added to the StacksNetwork interface
+- Add cvToString() method for converting ClarityValue objects to their string (source code) representation
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/stacks-transactions",
-  "version": "0.3.0-alpha.6",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -809,6 +809,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "@types/common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@types/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-htRqZr5qn8EzMelhX/Xmx142z218lLyGaeZ3YR8jlze4TATRU9huKKvuBmAJEW4LCC4pnY1N6JAm6p85fMHjhg==",
       "dev": true
     },
     "@types/elliptic": {
@@ -2617,6 +2623,12 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
       "dev": true
     },
     "commondir": {

--- a/package.json
+++ b/package.json
@@ -44,9 +44,11 @@
   "license": "GPL-3.0",
   "devDependencies": {
     "@blockstack/eslint-config": "^1.0.2",
+    "@types/common-tags": "^1.8.0",
     "@types/jest": "^25.1.3",
     "@types/node": "^13.7.0",
     "babel-loader": "^8.0.6",
+    "common-tags": "^1.8.0",
     "core-js": "^3.2.1",
     "cross-env": "^5.2.1",
     "eslint": "^6.8.0",

--- a/src/clarity/clarityValue.ts
+++ b/src/clarity/clarityValue.ts
@@ -11,6 +11,8 @@ import {
   ListCV,
   TupleCV,
 } from '.';
+import { principalToString } from './types/principalCV';
+import { CLARITY_INT_SIZE } from '../constants';
 
 /**
  * Type IDs corresponding to each of the Clarity value types as described here:
@@ -44,6 +46,40 @@ export type ClarityValue =
   | ResponseOkCV
   | ListCV
   | TupleCV;
+
+export function cvToString(val: ClarityValue, encoding?: 'ascii' | 'hex'): string {
+  switch (val.type) {
+    case ClarityType.BoolTrue:
+      return 'true';
+    case ClarityType.BoolFalse:
+      return 'false';
+    case ClarityType.Int:
+      return val.value.fromTwos(CLARITY_INT_SIZE).toString();
+    case ClarityType.UInt:
+      return val.value.toString();
+    case ClarityType.Buffer:
+      const bufferString =
+        encoding === 'hex' ? val.buffer.toString('hex') : val.buffer.toString('ascii');
+      return `"${bufferString}"`;
+    case ClarityType.OptionalNone:
+      return 'none';
+    case ClarityType.OptionalSome:
+      return `(some ${cvToString(val.value, encoding)})`;
+    case ClarityType.ResponseErr:
+      return `(err ${cvToString(val.value, encoding)})`;
+    case ClarityType.ResponseOk:
+      return `(ok ${cvToString(val.value, encoding)})`;
+    case ClarityType.PrincipalStandard:
+    case ClarityType.PrincipalContract:
+      return principalToString(val);
+    case ClarityType.List:
+      return `(list ${val.list.map(v => cvToString(v, encoding)).join(' ')})`;
+    case ClarityType.Tuple:
+      return `(tuple ${Object.keys(val.data)
+        .map(key => `(${key} ${cvToString(val.data[key], encoding)})`)
+        .join(' ')})`;
+  }
+}
 
 export function getCVTypeString(val: ClarityValue): string {
   switch (val.type) {

--- a/src/clarity/clarityValue.ts
+++ b/src/clarity/clarityValue.ts
@@ -13,6 +13,7 @@ import {
 } from '.';
 import { principalToString } from './types/principalCV';
 import { CLARITY_INT_SIZE } from '../constants';
+import { isClarityName } from '../utils';
 
 /**
  * Type IDs corresponding to each of the Clarity value types as described here:
@@ -47,7 +48,7 @@ export type ClarityValue =
   | ListCV
   | TupleCV;
 
-export function cvToString(val: ClarityValue, encoding?: 'ascii' | 'hex'): string {
+export function cvToString(val: ClarityValue, encoding: 'tryAscii' | 'hex' = 'tryAscii'): string {
   switch (val.type) {
     case ClarityType.BoolTrue:
       return 'true';
@@ -58,9 +59,12 @@ export function cvToString(val: ClarityValue, encoding?: 'ascii' | 'hex'): strin
     case ClarityType.UInt:
       return val.value.toString();
     case ClarityType.Buffer:
-      const bufferString =
-        encoding === 'hex' ? val.buffer.toString('hex') : val.buffer.toString('ascii');
-      return `"${bufferString}"`;
+      if (encoding === 'tryAscii') {
+        try {
+          return `"${val.buffer.toString('ascii')}"`;
+        } catch (e) {}
+      }
+      return `0x${val.buffer.toString('hex')}`;
     case ClarityType.OptionalNone:
       return 'none';
     case ClarityType.OptionalSome:

--- a/src/clarity/clarityValue.ts
+++ b/src/clarity/clarityValue.ts
@@ -60,12 +60,10 @@ export function cvToString(val: ClarityValue, encoding: 'tryAscii' | 'hex' = 'tr
       return val.value.toString();
     case ClarityType.Buffer:
       if (encoding === 'tryAscii') {
-        try {
-          const ascii = val.buffer.toString('ascii');
-          if (/[ -~]/.test(ascii)) {
-            return `"${ascii}"`;
-          }
-        } catch (e) {}
+        const str = val.buffer.toString('ascii');
+        if (/[ -~]/.test(str)) {
+          return JSON.stringify(str);
+        }
       }
       return `0x${val.buffer.toString('hex')}`;
     case ClarityType.OptionalNone:

--- a/src/clarity/clarityValue.ts
+++ b/src/clarity/clarityValue.ts
@@ -61,7 +61,10 @@ export function cvToString(val: ClarityValue, encoding: 'tryAscii' | 'hex' = 'tr
     case ClarityType.Buffer:
       if (encoding === 'tryAscii') {
         try {
-          return `"${val.buffer.toString('ascii')}"`;
+          const ascii = val.buffer.toString('ascii');
+          if (/[ -~]/.test(ascii)) {
+            return `"${ascii}"`;
+          }
         } catch (e) {}
       }
       return `0x${val.buffer.toString('hex')}`;

--- a/src/clarity/index.ts
+++ b/src/clarity/index.ts
@@ -1,4 +1,4 @@
-import { ClarityValue, ClarityType, getCVTypeString } from './clarityValue';
+import { ClarityValue, ClarityType, getCVTypeString, cvToString } from './clarityValue';
 import { BooleanCV, TrueCV, FalseCV, trueCV, falseCV } from './types/booleanCV';
 import { IntCV, UIntCV, intCV, uintCV } from './types/intCV';
 import { BufferCV, bufferCV, bufferCVFromString } from './types/bufferCV';
@@ -68,3 +68,6 @@ export {
 
 // Serialization
 export { serializeCV, deserializeCV };
+
+// toString
+export { cvToString };

--- a/tests/src/clarity-tests.ts
+++ b/tests/src/clarity-tests.ts
@@ -1,3 +1,4 @@
+import { oneLineTrim } from 'common-tags';
 import { deserializeAddress } from '../../src/types';
 import {
   ClarityValue,
@@ -23,6 +24,7 @@ import {
 } from '../../src/clarity';
 import { contractPrincipalCVFromStandard } from '../../src/clarity/types/principalCV';
 import { BufferReader } from '../../src/bufferReader';
+import { cvToString } from '../../src/clarity/clarityValue';
 
 const ADDRESS = 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B';
 
@@ -263,5 +265,44 @@ describe('Clarity Types', () => {
       const serialized = serializeCV(tuple).toString('hex');
       expect(serialized).toEqual('0c000000020362617a0906666f6f62617203');
     });
+  });
+
+  test('Clarity Value To String', () => {
+    const tuple = tupleCV({
+      a: intCV(-1),
+      b: uintCV(1),
+      c: bufferCV(Buffer.from('test')),
+      d: trueCV(),
+      e: someCV(trueCV()),
+      f: noneCV(),
+      g: standardPrincipalCV(ADDRESS),
+      h: contractPrincipalCV(ADDRESS, 'test'),
+      i: responseOkCV(trueCV()),
+      j: responseErrorCV(falseCV()),
+      k: listCV([trueCV(), falseCV()]),
+      l: tupleCV({
+        a: trueCV(),
+        b: falseCV(),
+      }),
+    });
+
+    const tupleString = cvToString(tuple);
+
+    expect(tupleString).toEqual(
+      oneLineTrim`
+      (tuple 
+        (a -1) 
+        (b 1) 
+        (c "test") 
+        (d true) 
+        (e (some true)) 
+        (f none) 
+        (g SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B) 
+        (h SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B.test) 
+        (i (ok true)) 
+        (j (err false)) 
+        (k (list true false)) 
+        (l (tuple (a true) (b false))))`
+    );
   });
 });

--- a/tests/src/clarity-tests.ts
+++ b/tests/src/clarity-tests.ts
@@ -267,42 +267,50 @@ describe('Clarity Types', () => {
     });
   });
 
-  test('Clarity Value To String', () => {
-    const tuple = tupleCV({
-      a: intCV(-1),
-      b: uintCV(1),
-      c: bufferCV(Buffer.from('test')),
-      d: trueCV(),
-      e: someCV(trueCV()),
-      f: noneCV(),
-      g: standardPrincipalCV(ADDRESS),
-      h: contractPrincipalCV(ADDRESS, 'test'),
-      i: responseOkCV(trueCV()),
-      j: responseErrorCV(falseCV()),
-      k: listCV([trueCV(), falseCV()]),
-      l: tupleCV({
-        a: trueCV(),
-        b: falseCV(),
-      }),
+  describe('Clarity Value To Clarity String Literal', () => {
+    test('Complex Tuple', () => {
+      const tuple = tupleCV({
+        a: intCV(-1),
+        b: uintCV(1),
+        c: bufferCV(Buffer.from('test')),
+        d: trueCV(),
+        e: someCV(trueCV()),
+        f: noneCV(),
+        g: standardPrincipalCV(ADDRESS),
+        h: contractPrincipalCV(ADDRESS, 'test'),
+        i: responseOkCV(trueCV()),
+        j: responseErrorCV(falseCV()),
+        k: listCV([trueCV(), falseCV()]),
+        l: tupleCV({
+          a: trueCV(),
+          b: falseCV(),
+        }),
+      });
+
+      const tupleString = cvToString(tuple);
+
+      expect(tupleString).toEqual(
+        oneLineTrim`
+        (tuple 
+          (a -1) 
+          (b 1) 
+          (c "test") 
+          (d true) 
+          (e (some true)) 
+          (f none) 
+          (g SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B) 
+          (h SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B.test) 
+          (i (ok true)) 
+          (j (err false)) 
+          (k (list true false)) 
+          (l (tuple (a true) (b false))))`
+      );
     });
 
-    const tupleString = cvToString(tuple);
-
-    expect(tupleString).toEqual(
-      oneLineTrim`
-      (tuple 
-        (a -1) 
-        (b 1) 
-        (c "test") 
-        (d true) 
-        (e (some true)) 
-        (f none) 
-        (g SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B) 
-        (h SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B.test) 
-        (i (ok true)) 
-        (j (err false)) 
-        (k (list true false)) 
-        (l (tuple (a true) (b false))))`
-    );
+    test('Hex Buffers', () => {
+      expect(cvToString(bufferCV(Buffer.from('\n', 'ascii')))).toEqual('0x0a');
+      expect(cvToString(bufferCV(Buffer.from('00', 'hex')))).toEqual('0x00');
+      expect(cvToString(bufferCV(Buffer.from([127])))).toEqual('0x7f');
+    });
   });
 });


### PR DESCRIPTION
This PR adds a function to convert TS Clarity Values to their string (source code) representation so they can be displayed easily. This is important for the Explorer.

relevant sidecar issue: https://github.com/blockstack/stacks-blockchain-sidecar/issues/99


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
