### PR TITLE
Function to convert ABI function to Clarity repr string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- abiFunctionToString() method for converting ABI function typedef to Clarity repr string
+
+### Changed
+- Changed the format that the type -> string functions output to match Clarity type repr
+
 ## v0.4.2 
 
 ### Added

--- a/src/clarity/clarityValue.ts
+++ b/src/clarity/clarityValue.ts
@@ -92,27 +92,27 @@ export function getCVTypeString(val: ClarityValue): string {
     case ClarityType.BoolFalse:
       return 'bool';
     case ClarityType.Int:
-      return 'int128';
+      return 'int';
     case ClarityType.UInt:
-      return 'uint128';
+      return 'uint';
     case ClarityType.Buffer:
-      return `buffer(${val.buffer.length})`;
+      return `(buff ${val.buffer.length})`;
     case ClarityType.OptionalNone:
-      return 'optional(none)';
+      return '(optional none)';
     case ClarityType.OptionalSome:
-      return `optional(${getCVTypeString(val.value)})`;
+      return `(optional ${getCVTypeString(val.value)})`;
     case ClarityType.ResponseErr:
-      return `responseError(${getCVTypeString(val.value)})`;
+      return `(responseError ${getCVTypeString(val.value)})`;
     case ClarityType.ResponseOk:
-      return `responseOk(${getCVTypeString(val.value)})`;
+      return `(responseOk ${getCVTypeString(val.value)})`;
     case ClarityType.PrincipalStandard:
     case ClarityType.PrincipalContract:
       return 'principal';
     case ClarityType.List:
-      return `list(${getCVTypeString(val.list[0])},${val.list.length})`;
+      return `(list ${val.list.length} ${getCVTypeString(val.list[0])})`;
     case ClarityType.Tuple:
-      return `tuple(${Object.keys(val.data)
-        .map(key => JSON.stringify(key) + ':' + getCVTypeString(val.data[key]))
-        .join(',')})`;
+      return `(tuple ${Object.keys(val.data)
+        .map(key => `(${key} ${getCVTypeString(val.data[key])})`)
+        .join(' ')})`;
   }
 }

--- a/src/contract-abi.ts
+++ b/src/contract-abi.ts
@@ -171,19 +171,22 @@ export { encodeClarityValue };
 
 export function getTypeString(val: ClarityAbiType): string {
   if (isClarityAbiPrimitive(val)) {
+    if (val === 'int128') {
+      return 'int';
+    } else if (val === 'uint128') {
+      return 'uint';
+    }
     return val;
   } else if (isClarityAbiBuffer(val)) {
-    return `buffer(${val.buffer.length})`;
+    return `(buff ${val.buffer.length})`;
   } else if (isClarityAbiResponse(val)) {
-    return `response(${getTypeString(val.response.ok)},${getTypeString(val.response.error)})`;
+    return `(response ${getTypeString(val.response.ok)} ${getTypeString(val.response.error)})`;
   } else if (isClarityAbiOptional(val)) {
-    return `optional(${getTypeString(val.optional)})`;
+    return `(optional ${getTypeString(val.optional)})`;
   } else if (isClarityAbiTuple(val)) {
-    return `tuple(${val.tuple
-      .map(t => JSON.stringify(t.name) + ':' + getTypeString(t.type))
-      .join(',')})`;
+    return `(tuple ${val.tuple.map(t => `(${t.name} ${getTypeString(t.type)})`).join(' ')})`;
   } else if (isClarityAbiList(val)) {
-    return `list(${getTypeString(val.list.type)},${val.list.length})`;
+    return `(list ${val.list.length} ${getTypeString(val.list.type)})`;
   } else {
     throw new Error(`Type string unsupported for Clarity type: ${JSON.stringify(val)}`);
   }

--- a/src/contract-abi.ts
+++ b/src/contract-abi.ts
@@ -204,6 +204,13 @@ export interface ClarityAbiFunction {
   };
 }
 
+export function abiFunctionToString(func: ClarityAbiFunction): string {
+  const access = func.access === 'read_only' ? 'read-only' : func.access;
+  return `(define-${access} (${func.name} ${func.args
+    .map(arg => `(${arg.name} ${getTypeString(arg.type)})`)
+    .join(' ')}))`;
+}
+
 export interface ClarityAbiVariable {
   name: string;
   access: 'variable' | 'constant';

--- a/tests/src/abi-tests.ts
+++ b/tests/src/abi-tests.ts
@@ -15,6 +15,7 @@ import {
   noneCV,
 } from '../../src';
 import { validateContractCall, ClarityAbi } from '../../src/contract-abi';
+import { oneLineTrim } from 'common-tags';
 
 const TEST_ABI: ClarityAbi = JSON.parse(readFileSync('./tests/src/abi/test-abi.json').toString());
 
@@ -70,27 +71,26 @@ test('ABI validation fail, tuple mistyped', () => {
   );
 
   expect(() => validateContractCall(payload, TEST_ABI)).toThrow(
-    // prettier-ignore
-    'Clarity function `tuple-test` expects argument 1 to be of type ' +
-      'tuple(' +
-        '"key1":bool,' +
-        '"key2":int128,' +
-        '"key3":uint128,' +
-        '"key4":principal,' +
-        '"key5":buffer(3),' +
-        '"key6":optional(bool),' +
-        '"key7":response(bool,bool),' +
-        '"key8":list(bool,2)), ' +
-      'not ' +
-      'tuple(' +
-        '"key1":bool,' +
-        '"key2":int128,' +
-        '"key3":uint128,' +
-        '"key4":principal,' +
-        '"key5":buffer(3),' +
-        '"key6":optional(none),' +
-        '"key7":responseError(bool),' +
-        '"key8":bool)'
+    oneLineTrim`
+    Clarity function \`tuple-test\` expects argument 1 to be of type 
+      (tuple 
+        (key1 bool) 
+        (key2 int) 
+        (key3 uint) 
+        (key4 principal) 
+        (key5 (buff 3)) 
+        (key6 (optional bool)) 
+        (key7 (response bool bool)) 
+        (key8 (list 2 bool))), not 
+      (tuple 
+        (key1 bool) 
+        (key2 int) 
+        (key3 uint) 
+        (key4 principal) 
+        (key5 (buff 3)) 
+        (key6 (optional none)) 
+        (key7 (responseError bool)) 
+        (key8 bool))`
   );
 });
 
@@ -119,26 +119,27 @@ test('ABI validation fail, tuple wrong key', () => {
   );
 
   expect(() => validateContractCall(payload, TEST_ABI)).toThrow(
-    // prettier-ignore
-    'Clarity function `tuple-test` expects argument 1 to be of type ' +
-      'tuple(' +
-        '"key1":bool,' +
-        '"key2":int128,' +
-        '"key3":uint128,' +
-        '"key4":principal,' +
-        '"key5":buffer(3),' +
-        '"key6":optional(bool),' +
-        '"key7":response(bool,bool),' +
-        '"key8":list(bool,2)), ' +
-      'not ' +
-      'tuple("wrong-key":bool,' +
-        '"key2":int128,' +
-        '"key3":uint128,' +
-        '"key4":principal,' +
-        '"key5":buffer(3),' +
-        '"key6":optional(bool),' +
-        '"key7":responseOk(bool),' +
-        '"key9":list(bool,2))'
+    oneLineTrim`
+    Clarity function \`tuple-test\` expects argument 1 to be of type 
+    (tuple 
+      (key1 bool) 
+      (key2 int) 
+      (key3 uint) 
+      (key4 principal) 
+      (key5 (buff 3)) 
+      (key6 (optional bool)) 
+      (key7 (response bool bool)) 
+      (key8 (list 2 bool))), not 
+    (tuple 
+      (wrong-key bool) 
+      (key2 int) 
+      (key3 uint) 
+      (key4 principal) 
+      (key5 (buff 3)) 
+      (key6 (optional bool)) 
+      (key7 (responseOk bool)) 
+      (key9 (list 2 bool)))
+    `
   );
 });
 

--- a/tests/src/abi-tests.ts
+++ b/tests/src/abi-tests.ts
@@ -14,7 +14,7 @@ import {
   responseErrorCV,
   noneCV,
 } from '../../src';
-import { validateContractCall, ClarityAbi } from '../../src/contract-abi';
+import { validateContractCall, ClarityAbi, abiFunctionToString } from '../../src/contract-abi';
 import { oneLineTrim } from 'common-tags';
 
 const TEST_ABI: ClarityAbi = JSON.parse(readFileSync('./tests/src/abi/test-abi.json').toString());
@@ -220,4 +220,8 @@ test('Validation fails when abi is missing specified function', () => {
   expect(() => validateContractCall(payload, TEST_ABI)).toThrow(
     "ABI doesn't contain a function with the name get-value"
   );
+});
+
+test('ABI function to repr string', () => {
+  expect(abiFunctionToString(TEST_ABI.functions[1])).toEqual('(define-public (hello (arg1 int)))');
 });

--- a/tests/src/abi/test-abi.json
+++ b/tests/src/abi/test-abi.json
@@ -16,6 +16,14 @@
         ]}}
       ],
       "outputs": { "type": { "response": { "ok": "bool", "error": "none" } } }
+    },
+    {
+      "name": "hello",
+      "access": "public",
+      "args": [
+        { "name": "arg1", "type": "int128" }
+      ],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "none" } } }
     }
   ],
   "variables": [],


### PR DESCRIPTION
## Description

1. Convert an ABI function typedef to a Clarity typedef string
2. Reformat output from type -> string functions

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
