### PR TITLE
Broadcast raw tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- ability to broadcast raw transactions using `broadcastRawTransaction()`
 - abiFunctionToString() method for converting ABI function typedef to Clarity repr string
 
 ### Changed

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -122,8 +122,21 @@ export async function broadcastTransaction(
   transaction: StacksTransaction,
   network: StacksNetwork
 ): Promise<string> {
-  const tx = transaction.serialize();
+  const rawTx = transaction.serialize();
+  const url = network.getBroadcastApiUrl();
 
+  return broadcastRawTransaction(rawTx, url);
+}
+
+/**
+ * Broadcast the signed transaction to a core node
+ *
+ * @param {Buffer} rawTx - the raw serialized transaction buffer to broadcast
+ * @param {string} url - the broadcast endpoint URL
+ *
+ * @returns {Promise} that resolves to a response if the operation succeeds
+ */
+export async function broadcastRawTransaction(rawTx: Buffer, url: string) {
   const requestHeaders = {
     'Content-Type': 'application/octet-stream',
   };
@@ -131,10 +144,8 @@ export async function broadcastTransaction(
   const options = {
     method: 'POST',
     headers: requestHeaders,
-    body: tx,
+    body: rawTx,
   };
-
-  const url = network.getBroadcastApiUrl();
 
   const response = await fetchPrivate(url, options);
   if (!response.ok) {


### PR DESCRIPTION
This PR enables broadcasting of a serialized transaction string in a buffer.

```
const rawTx = transaction.serialize();
const url = network.getBroadcastApiUrl();
broadcastRawTransaction(rawTx, url);
```

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
