### PR TITLE
fix: use blockstack prettier config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   preset: 'ts-jest',
-  testRegex: '(/tests/src/.*-tests.ts$)'
+  testRegex: '(/tests/src/.*-tests.ts$)',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -256,9 +256,9 @@
       }
     },
     "@blockstack/prettier-config": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@blockstack/prettier-config/-/prettier-config-0.0.5.tgz",
-      "integrity": "sha512-A+wfdVwD1Sxd/D3PPJI67Evo7q2fp15hCOFLB5jmzcS1MdN8BQdFm6j51Sti8xLN4qHmuYkicbFBUluGx2h63g==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@blockstack/prettier-config/-/prettier-config-0.0.6.tgz",
+      "integrity": "sha512-ke0MdyblmoUqSJBEutsG8/6G7KAjCB+uOcgZHPJvJr4R+i5yRhT4GSe5nV/wREINuK0jj2GvaA6qlx4PQTKQUA==",
       "dev": true
     },
     "@cnakazawa/watch": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "build:node:watch": "shx rm -rf lib && tsc -p tsconfig.build.json --watch",
     "lint": "eslint ./src ./tests --ext .ts",
     "lint:fix": "eslint ./src ./tests --ext .ts --fix",
+    "lint:prettier": "prettier --check \"src/**/*.{ts,tsx}\" *.js *.json",
+    "lint:prettier:fix": "prettier --write \"src/**/*.{ts,tsx}\" *.js *.json",
     "test": "jest --config ./jest.config.js --coverage",
     "prepublishOnly": "npm run test && npm run build",
     "prepare": "npm run build",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "license": "GPL-3.0",
   "devDependencies": {
     "@blockstack/eslint-config": "^1.0.2",
+    "@blockstack/prettier-config": "0.0.6",
     "@types/common-tags": "^1.8.0",
     "@types/jest": "^25.1.3",
     "@types/node": "^13.7.0",
@@ -110,5 +111,6 @@
       "html",
       "lcov"
     ]
-  }
+  },
+  "prettier": "@blockstack/prettier-config"
 }

--- a/src/contract-abi.ts
+++ b/src/contract-abi.ts
@@ -343,8 +343,9 @@ export function validateContractCall(payload: ContractCallPayload, abi: ClarityA
 
       if (!matchType(payloadArg, abiArg.type)) {
         throw new Error(
-          `Clarity function \`${payload.functionName.content}\` expects argument ${i +
-            1} to be of type ${getTypeString(abiArg.type)}, not ${getCVTypeString(payloadArg)}`
+          `Clarity function \`${payload.functionName.content}\` expects argument ${
+            i + 1
+          } to be of type ${getTypeString(abiArg.type)}, not ${getCVTypeString(payloadArg)}`
         );
       }
     }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,9 +4,7 @@
     "noEmit": false,
     "rootDir": "./src",
     "outDir": "./lib",
-    "declaration": true,
+    "declaration": true
   },
-  "include": [
-    "src/**/*"
-  ]
+  "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,11 +7,7 @@
     "sourceMap": true,
     "outDir": "lib",
     "esModuleInterop": false,
-    "allowSyntheticDefaultImports": false,
+    "allowSyntheticDefaultImports": false
   },
-  "include": [
-    "src/index.ts",
-    "src/**/*",
-    "tests/**/*"
-  ]
+  "include": ["src/index.ts", "src/**/*", "tests/**/*"]
 }

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -8,9 +8,7 @@
     "outDir": "lib",
     "sourceMap": true
   },
-  "include": [
-    "src",
-  ],
+  "include": ["src"],
   "typedocOptions": {
     "readme": "overview.md",
     "mode": "file",
@@ -18,7 +16,7 @@
     "excludeProtected": true,
     "excludeExternals": true,
     "excludeNotExported": false,
-    "includes" : "mdincludes",
+    "includes": "mdincludes",
     "includeDeclarations": false,
     "gitRevision": "master",
     "listInvalidSymbolLinks": true,


### PR DESCRIPTION
## Description

When working on #87 I noticed that this project was not using our prettier config: `@blockstack/prettier-config`. This PR adds some npm tasks and runs them throughout the project. 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
Nope, just code formatting

## Are documentation updates required?
Nope.

## Checklist
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
