### PR TITLE
feat: parseToCV function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Add `parseToCV()` utility function to convert string input to the appropriate Clarity value based on the Clarity ABI type specified by the contract function
+
 ## v0.4.4
 
 ### Added
-- ability to broadcast raw transactions using `broadcastRawTransaction()`
-- abiFunctionToString() method for converting ABI function typedef to Clarity repr string
+- Ability to broadcast raw transactions using `broadcastRawTransaction()`
+- `abiFunctionToString()` method for converting ABI function typedef to Clarity repr string
 
 ### Changed
 - Changed the format that the type -> string functions output to match Clarity type repr

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/stacks-transactions",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/contract-abi.ts
+++ b/src/contract-abi.ts
@@ -369,7 +369,7 @@ export function validateContractCall(payload: ContractCallPayload, abi: ClarityA
  *
  * @returns {ClarityValue} returns a Clarity value
  */
-export function parseToAbiType(input: string, type: ClarityAbiType): ClarityValue {
+export function parseToCV(input: string, type: ClarityAbiType): ClarityValue {
   const typeString = getTypeString(type);
   if (isClarityAbiPrimitive(type)) {
     if (type === 'uint128') {

--- a/src/contract-abi.ts
+++ b/src/contract-abi.ts
@@ -377,7 +377,13 @@ export function parseToCV(input: string, type: ClarityAbiType): ClarityValue {
     } else if (type === 'int128') {
       return intCV(input);
     } else if (type === 'bool') {
-      return input == 'True' ? trueCV() : falseCV();
+      if (input.toLowerCase() === 'true') {
+        return trueCV();
+      } else if (input.toLowerCase() === 'false') {
+        return falseCV();
+      } else {
+        throw new Error(`Invalid bool value: ${input}`);
+      }
     } else if (type === 'principal') {
       if (input.includes('.')) {
         const [address, contractName] = input.split('.');
@@ -389,6 +395,10 @@ export function parseToCV(input: string, type: ClarityAbiType): ClarityValue {
       throw new Error(`Contract function contains unsupported Clarity ABI type: ${typeString}`);
     }
   } else if (isClarityAbiBuffer(type)) {
+    const inputLength = Buffer.from(input).byteLength
+    if (inputLength > type.buffer.length) {
+      throw new Error(`Input exceeds specified buffer length limit of ${type.buffer.length}`);
+    }
     return bufferCVFromString(input);
   } else if (isClarityAbiResponse(type)) {
     throw new Error(`Contract function contains unsupported Clarity ABI type: ${typeString}`);

--- a/tests/src/abi-tests.ts
+++ b/tests/src/abi-tests.ts
@@ -19,7 +19,7 @@ import {
   validateContractCall,
   ClarityAbi,
   abiFunctionToString,
-  parseToAbiType,
+  parseToCV,
   ClarityAbiType,
 } from '../../src/contract-abi';
 import { oneLineTrim } from 'common-tags';
@@ -250,13 +250,13 @@ test('Parse string input using ABI arg type', () => {
   const principalFunctionArgType: ClarityAbiType = 'principal';
   const bufferFunctionArgType: ClarityAbiType = { buffer: { length: 1 } };
 
-  const uintCVResult = parseToAbiType(uintString, uintFunctionArgType);
-  const intCVResult = parseToAbiType(intString, intFunctionArgType);
-  const boolCVTrueResult = parseToAbiType(boolStringTrue, boolFunctionArgType);
-  const boolCVFalseResult = parseToAbiType(boolStringFalse, boolFunctionArgType);
-  const standardPrincipalCVResult = parseToAbiType(standardPrincipalString, principalFunctionArgType);
-  const contractPrincipalCVResult = parseToAbiType(contractPrincipalString, principalFunctionArgType);
-  const bufferCVResult = parseToAbiType(bufferString, bufferFunctionArgType);
+  const uintCVResult = parseToCV(uintString, uintFunctionArgType);
+  const intCVResult = parseToCV(intString, intFunctionArgType);
+  const boolCVTrueResult = parseToCV(boolStringTrue, boolFunctionArgType);
+  const boolCVFalseResult = parseToCV(boolStringFalse, boolFunctionArgType);
+  const standardPrincipalCVResult = parseToCV(standardPrincipalString, principalFunctionArgType);
+  const contractPrincipalCVResult = parseToCV(contractPrincipalString, principalFunctionArgType);
+  const bufferCVResult = parseToCV(bufferString, bufferFunctionArgType);
 
   expect(uintCVResult).toEqual(uintCV(uintString));
   expect(intCVResult).toEqual(intCV(intString));

--- a/tests/src/abi-tests.ts
+++ b/tests/src/abi-tests.ts
@@ -6,6 +6,7 @@ import {
   tupleCV,
   uintCV,
   standardPrincipalCV,
+  contractPrincipalCV,
   bufferCVFromString,
   someCV,
   falseCV,
@@ -14,7 +15,13 @@ import {
   responseErrorCV,
   noneCV,
 } from '../../src';
-import { validateContractCall, ClarityAbi, abiFunctionToString } from '../../src/contract-abi';
+import {
+  validateContractCall,
+  ClarityAbi,
+  abiFunctionToString,
+  parseToAbiType,
+  ClarityAbiType,
+} from '../../src/contract-abi';
 import { oneLineTrim } from 'common-tags';
 
 const TEST_ABI: ClarityAbi = JSON.parse(readFileSync('./tests/src/abi/test-abi.json').toString());
@@ -224,4 +231,38 @@ test('Validation fails when abi is missing specified function', () => {
 
 test('ABI function to repr string', () => {
   expect(abiFunctionToString(TEST_ABI.functions[1])).toEqual('(define-public (hello (arg1 int)))');
+});
+
+test('Parse string input using ABI arg type', () => {
+  const uintString = '123';
+  const intString = '234';
+  const boolStringTrue = 'True';
+  const boolStringFalse = 'False';
+  const standardPrincipalString = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const address = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'kv-store';
+  const contractPrincipalString = `${address}.${contractName}`;
+  const bufferString = 'test 321';
+
+  const uintFunctionArgType: ClarityAbiType = 'uint128';
+  const intFunctionArgType: ClarityAbiType = 'int128';
+  const boolFunctionArgType: ClarityAbiType = 'bool';
+  const principalFunctionArgType: ClarityAbiType = 'principal';
+  const bufferFunctionArgType: ClarityAbiType = { buffer: { length: 1 } };
+
+  const uintCVResult = parseToAbiType(uintString, uintFunctionArgType);
+  const intCVResult = parseToAbiType(intString, intFunctionArgType);
+  const boolCVTrueResult = parseToAbiType(boolStringTrue, boolFunctionArgType);
+  const boolCVFalseResult = parseToAbiType(boolStringFalse, boolFunctionArgType);
+  const standardPrincipalCVResult = parseToAbiType(standardPrincipalString, principalFunctionArgType);
+  const contractPrincipalCVResult = parseToAbiType(contractPrincipalString, principalFunctionArgType);
+  const bufferCVResult = parseToAbiType(bufferString, bufferFunctionArgType);
+
+  expect(uintCVResult).toEqual(uintCV(uintString));
+  expect(intCVResult).toEqual(intCV(intString));
+  expect(boolCVTrueResult).toEqual(trueCV());
+  expect(boolCVFalseResult).toEqual(falseCV());
+  expect(standardPrincipalCVResult).toEqual(standardPrincipalCV(standardPrincipalString));
+  expect(contractPrincipalCVResult).toEqual(contractPrincipalCV(address, contractName));
+  expect(bufferCVResult).toEqual(bufferCVFromString(bufferString));
 });

--- a/tests/src/abi-tests.ts
+++ b/tests/src/abi-tests.ts
@@ -248,7 +248,11 @@ test('Parse string input using ABI arg type', () => {
   const intFunctionArgType: ClarityAbiType = 'int128';
   const boolFunctionArgType: ClarityAbiType = 'bool';
   const principalFunctionArgType: ClarityAbiType = 'principal';
-  const bufferFunctionArgType: ClarityAbiType = { buffer: { length: 1 } };
+  const bufferFunctionArgType: ClarityAbiType = {
+    buffer: {
+      length: Buffer.from(bufferString).byteLength,
+    },
+  };
 
   const uintCVResult = parseToCV(uintString, uintFunctionArgType);
   const intCVResult = parseToCV(intString, intFunctionArgType);


### PR DESCRIPTION
This PR adds a `parseToCV` function that converts string input to the appropriate Clarity value based on the Clarity ABI type specified by the contract function. This is useful for converting user input from UI into args for contract function calls dynamically.

Example:
```
// First we need to fetch the ABI of the contract
getAbi(
  contractAddress,
  contractName,
  txNetwork
).then((abi) => {
  // Filter the function signature that we need
  const filtered = abi.functions.filter(fn => fn.name === functionName);    
  const expectedArgs = filtered[0].args;
  const argsCV = []

  // Use parseToCV() to convert to Clarity value
  for (let i = 0; i < expectedArgs.length; i++) {
    const expectedArg = expectedArgs[i];
    const userInput = userInputs[expectedArg.name];
    argsCV.push(parseToCV(userInput, expectedArg.type));
  }
})
```

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
