### PR TITLE
feat: update to stable testnet url

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -33,5 +33,5 @@ export class StacksMainnet implements StacksNetwork {
 export class StacksTestnet extends StacksMainnet implements StacksNetwork {
   version = TransactionVersion.Testnet;
   chainId = ChainID.Testnet;
-  coreApiUrl = 'http://neon.blockstack.org:20443';
+  coreApiUrl = 'http://testnet-master.blockstack.org:20443';
 }


### PR DESCRIPTION
This PR updates the testnet network config to use the stable `testnet-master.blockstack.org` URL. 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
