### PR TITLE
Fix contract deploy fee estimation error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
   "extends": [
     '@blockstack'
-  ]
+  ],
+  "rules": {
+    "@typescript-eslint/no-unnecessary-type-assertion": ["off"]
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - tx broadcast now returns a response type which may contain an error
+- fixed contract deploy auto fee estimation
 
 ## v0.4.6
 - Updates the testnet network config to use stable `testnet-master.blockstack.org` URL

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -440,7 +440,7 @@ export async function makeSmartContractDeploy(
   );
 
   if (!txOptions.fee) {
-    const txFee = await estimateTransfer(transaction, options.network);
+    const txFee = await estimateContractDeploy(transaction, options.network);
     transaction.setFee(txFee);
   }
 


### PR DESCRIPTION
This fixes the contract deploy fee estimation function. Previously this was causing `makeSmartContractDeploy` fail when not specifying a fee. Also turns off `no-unnecessary-type-assertion` eslint warning.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No 

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
