### PR TITLE
fix: abi validation should allow buffers less than the specified size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - tx broadcast now returns a response type which may contain an error
+- allow buffers to be less than or equal to the size specified in the ABI when validating contract-call args
 
 ## v0.4.6
 - Updates the testnet network config to use stable `testnet-master.blockstack.org` URL

--- a/src/contract-abi.ts
+++ b/src/contract-abi.ts
@@ -251,7 +251,7 @@ function matchType(cv: ClarityValue, abiType: ClarityAbiType): boolean {
     case ClarityType.Buffer:
       return (
         union.id === ClarityAbiTypeId.ClarityAbiTypeBuffer &&
-        union.type.buffer.length === cv.buffer.length
+        union.type.buffer.length >= cv.buffer.length
       );
     case ClarityType.OptionalNone:
       return (

--- a/tests/src/abi-tests.ts
+++ b/tests/src/abi-tests.ts
@@ -54,6 +54,32 @@ test('ABI validation', () => {
   validateContractCall(payload, TEST_ABI);
 });
 
+test('ABI validation buffer', () => {
+  const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'test';
+  const functionName = 'buffer-test';
+
+  const payloadCorrectBuffer = createContractCallPayload(
+    contractAddress,
+    contractName,
+    functionName,
+    [bufferCVFromString('test')]
+  );
+
+  validateContractCall(payloadCorrectBuffer, TEST_ABI);
+
+  const payloadBufferTooBig = createContractCallPayload(
+    contractAddress,
+    contractName,
+    functionName,
+    [bufferCVFromString('too large')]
+  );
+
+  expect(() => validateContractCall(payloadBufferTooBig, TEST_ABI)).toThrow(
+    'Clarity function `buffer-test` expects argument 1 to be of type (buff 6), not (buff 9)'
+  );
+});
+
 test('ABI validation fail, tuple mistyped', () => {
   const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
   const contractName = 'test';
@@ -169,7 +195,7 @@ test('ABI validation fail, wrong number of args', () => {
   );
 });
 
-test('Validation fails when ABI has multiple functions with the same nam', () => {
+test('Validation fails when ABI has multiple functions with the same name', () => {
   const abi: ClarityAbi = {
     functions: [
       {

--- a/tests/src/abi/test-abi.json
+++ b/tests/src/abi/test-abi.json
@@ -24,6 +24,14 @@
         { "name": "arg1", "type": "int128" }
       ],
       "outputs": { "type": { "response": { "ok": "bool", "error": "none" } } }
+    },
+    {
+      "name": "buffer-test",
+      "access": "public",
+      "args": [
+        { "name": "arg1", "type": { "buffer": { "length": 6 } } }
+      ],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "none" } } }
     }
   ],
   "variables": [],


### PR DESCRIPTION
## Description

Allow buffers provided as contract-call arguments to be less than or equal to the size specified in the ABI.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
