### PR TITLE
refactor: rename makeSmartContractDeploy for makeContractDeploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- renamed `makeSmartContractDeploy()` to `makeContractDeploy()`
 - tx broadcast now returns a response type which may contain an error
 - fixed contract deploy auto fee estimation
 - allow buffers to be less than or equal to the size specified in the ABI when validating contract-call args

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ broadcastTransaction(transaction, network);
 ## Smart Contract Deploy Transaction
 
 ```javascript
-import { makeSmartContractDeploy, StacksMainnet, broadcastTransaction } from '@blockstack/stacks-transactions';
+import { makeContractDeploy, StacksMainnet, broadcastTransaction } from '@blockstack/stacks-transactions';
 const BigNum = require('bn.js');
 
 const network = new StacksMainnet();
@@ -75,7 +75,7 @@ const txOptions = {
   network,
 };
 
-const transaction = await makeSmartContractDeploy(txOptions);
+const transaction = await makeContractDeploy(txOptions);
 
 broadcastTransaction(transaction, network);
 ```

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -395,7 +395,7 @@ export function estimateContractDeploy(
  *
  * @return {StacksTransaction}
  */
-export async function makeSmartContractDeploy(
+export async function makeContractDeploy(
   txOptions: ContractDeployOptions
 ): Promise<StacksTransaction> {
   const defaultOptions = {

--- a/tests/src/builder-tests.ts
+++ b/tests/src/builder-tests.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 
 import {
   makeSTXTokenTransfer,
-  makeSmartContractDeploy,
+  makeContractDeploy,
   makeContractCall,
   makeStandardSTXPostCondition,
   makeContractSTXPostCondition,
@@ -185,7 +185,7 @@ test('Make smart contract deploy', async () => {
   const fee = new BigNum(0);
   const nonce = new BigNum(0);
 
-  const transaction = await makeSmartContractDeploy({
+  const transaction = await makeContractDeploy({
     contractName,
     codeBody,
     senderKey,


### PR DESCRIPTION
This PR renames the `makeSmartContractDeploy()` function to `makeContractDeploy`. 

Resolves: https://github.com/blockstack/stacks-transactions-js/issues/76

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
