### PR TITLE
fix: serialize uint strings with literal u prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- `cvToString()` serializes uints with literal `"u"` prefix.
+
 ## v0.5.0
 ### Changed
 - renamed `makeSmartContractDeploy()` to `makeContractDeploy()`

--- a/src/clarity/clarityValue.ts
+++ b/src/clarity/clarityValue.ts
@@ -57,7 +57,7 @@ export function cvToString(val: ClarityValue, encoding: 'tryAscii' | 'hex' = 'tr
     case ClarityType.Int:
       return val.value.fromTwos(CLARITY_INT_SIZE).toString();
     case ClarityType.UInt:
-      return val.value.toString();
+      return `u${val.value.toString()}`;
     case ClarityType.Buffer:
       if (encoding === 'tryAscii') {
         const str = val.buffer.toString('ascii');

--- a/tests/src/clarity-tests.ts
+++ b/tests/src/clarity-tests.ts
@@ -70,13 +70,13 @@ describe('Clarity Types', () => {
     test('IntCV', () => {
       const int = intCV(10);
       const serializedDeserialized = serializeDeserialize(int) as IntCV;
-      expect(serializedDeserialized.value.toString()).toEqual(int.value.toString());
+      expect(cvToString(serializedDeserialized)).toEqual(cvToString(int));
     });
 
     test('UIntCV', () => {
       const uint = uintCV(10);
       const serializedDeserialized = serializeDeserialize(uint) as UIntCV;
-      expect(serializedDeserialized.value.toString()).toEqual(uint.value.toString());
+      expect(cvToString(serializedDeserialized)).toEqual(cvToString(uint));
     });
 
     test('Standard Principal', () => {
@@ -293,7 +293,7 @@ describe('Clarity Types', () => {
         oneLineTrim`
         (tuple 
           (a -1) 
-          (b 1) 
+          (b u1) 
           (c "test") 
           (d true) 
           (e (some true)) 


### PR DESCRIPTION
## Description

This PR introduces a slight change to the `cvToString()` function. Uints are now serialized like `"u10"` instead of like `"10"`.

Issue: https://github.com/blockstack/stacks-blockchain/issues/1699

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
