### PR TITLE
feat: Sponsored transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Added ability to create sponsored transactions using `sponsorTransaction()`
+
 ## v0.5.0
 ### Changed
 - renamed `makeSmartContractDeploy()` to `makeContractDeploy()`

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The serialized transaction can now be passed to the sponsoring party which will 
 import { sponsorTransaction, BufferReader, deserializeTransaction, broadcastTransaction } from '@blockstack/stacks-transactions';
 const BigNum = require('bn.js');
 
-const bufferReader = new BufferReader(serializedTx);
+const bufferReader = new BufferReader(Buffer.from(serializedTx));
 const deserializedTx = deserializeTransaction(bufferReader);
 const sponsorKey = 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01';
 const fee = BigNum(1000);

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ const sponsorOptions = {
   fee,
 }
 
-const sponsoredTx = sponsorTransaction(sponsorOptions);
+const sponsoredTx = await sponsorTransaction(sponsorOptions);
 
 const network = new StacksMainnet();
 broadcastTransaction(sponsoredTx, network);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/stacks-transactions",
-  "version": "0.4.6",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -33,6 +33,7 @@ import {
   NotImplementedError,
   DeserializationError,
   SigningError,
+  VerificationError,
 } from './errors';
 import { create } from 'domain';
 
@@ -243,6 +244,22 @@ export class SpendingCondition extends Deserializable {
   }
 
   verify(initialSigHash: string, authType: AuthType): string {
+    if (this.fee === undefined) {
+      throw new VerificationError('"Spending condition fee" is undefined');
+    }
+
+    if (this.nonce === undefined) {
+      throw new VerificationError('"Spending condition nonce" is undefined');
+    }
+
+    if (this.pubKeyEncoding === undefined) {
+      throw new VerificationError('"Spending condition pub key encoding" is undefined');
+    }
+
+    if (this.signature === undefined) {
+      throw new VerificationError('"Spending condition signature" is undefined');
+    }
+
     if (this.singleSig()) {
       return this.verifySingleSig(initialSigHash, authType);
     } else {

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -9,7 +9,12 @@ import {
 
 import { BufferArray, txidFromData, sha512_256, leftPadHex } from './utils';
 
-import { Address, addressFromPublicKeys, addressFromVersionHash } from './types';
+import { 
+  Address, 
+  createEmptyAddress, 
+  addressFromPublicKeys, 
+  addressFromVersionHash 
+} from './types';
 
 import {
   StacksPublicKey,
@@ -18,11 +23,18 @@ import {
   isCompressed,
   signWithKey,
   getPublicKey,
+  publicKeyFromSignature,
 } from './keys';
 
 import * as BigNum from 'bn.js';
 import { BufferReader } from './bufferReader';
-import { SerializationError, NotImplementedError, DeserializationError } from './errors';
+import { 
+  SerializationError, 
+  NotImplementedError, 
+  DeserializationError, 
+  SigningError 
+} from './errors';
+import { create } from 'domain';
 
 abstract class Deserializable {
   abstract serialize(): Buffer;
@@ -91,6 +103,7 @@ export class SpendingCondition extends Deserializable {
         createStacksPublicKey(pubKey),
       ]);
     }
+
     this.nonce = nonce;
     this.fee = fee;
     if (pubKey) {
@@ -149,7 +162,7 @@ export class SpendingCondition extends Deserializable {
 
   static makeSigHashPostSign(
     curSigHash: string,
-    publicKey: StacksPublicKey,
+    pubKeyEncoding: PubKeyEncoding,
     signature: MessageSignature
   ): string {
     // new hash combines the previous hash and all the new data this signature will add.  This
@@ -157,9 +170,6 @@ export class SpendingCondition extends Deserializable {
     // * the public key compression flag
     // * the signature
     const hashLength = 32 + 1 + RECOVERABLE_ECDSA_SIG_LENGTH_BYTES;
-    const pubKeyEncoding = isCompressed(publicKey)
-      ? PubKeyEncoding.Compressed
-      : PubKeyEncoding.Uncompressed;
 
     const sigHash = curSigHash + leftPadHex(pubKeyEncoding.toString(16)) + signature.toString();
 
@@ -167,7 +177,7 @@ export class SpendingCondition extends Deserializable {
       throw Error('Invalid signature hash length');
     }
 
-    return new sha512_256().update(sigHash).digest('hex');
+    return txidFromData(Buffer.from(sigHash, 'hex'));
   }
 
   static nextSignature(
@@ -181,14 +191,74 @@ export class SpendingCondition extends Deserializable {
     nextSigHash: string;
   } {
     const sigHashPreSign = this.makeSigHashPreSign(curSigHash, authType, fee, nonce);
+
     const signature = signWithKey(privateKey, sigHashPreSign);
     const publicKey = getPublicKey(privateKey);
-    const nextSigHash = this.makeSigHashPostSign(sigHashPreSign, publicKey, signature);
+    const publicKeyEncoding = isCompressed(publicKey) 
+      ? PubKeyEncoding.Compressed : PubKeyEncoding.Uncompressed;
+    const nextSigHash = this.makeSigHashPostSign(sigHashPreSign, publicKeyEncoding, signature);
 
     return {
       nextSig: signature,
       nextSigHash,
     };
+  }
+
+  static nextVerification(
+    initialSigHash: string,
+    authType: AuthType,
+    fee: BigNum,
+    nonce: BigNum,
+    pubKeyEncoding: PubKeyEncoding,
+    signature: MessageSignature,
+  ) {
+    const sigHashPreSign = this.makeSigHashPreSign(initialSigHash, authType, fee, nonce);
+
+    const publicKey = createStacksPublicKey(publicKeyFromSignature(sigHashPreSign, signature));
+
+    const nextSigHash = this.makeSigHashPostSign(sigHashPreSign, PubKeyEncoding.Compressed, signature);
+
+    return {
+      pubKey: publicKey,
+      nextSigHash,
+    }
+  }
+
+  static newInitialSigHash(): SpendingCondition {
+    const spendingCondition = new this(
+      AddressHashMode.SerializeP2PKH, 
+      "",
+      new BigNum(0),
+      new BigNum(0)
+    )
+    spendingCondition.signerAddress = createEmptyAddress();
+    spendingCondition.pubKeyEncoding = PubKeyEncoding.Compressed;
+    spendingCondition.signature = MessageSignature.empty();
+    return spendingCondition;
+  }
+
+  verify(initialSigHash: string, authType: AuthType): string {
+    if (this.singleSig()) {
+      return this.verifySingleSig(initialSigHash, authType);
+    } else {
+      // TODO: verify multisig
+      return "";
+    }
+  }
+
+  verifySingleSig(initialSigHash: string, authType: AuthType): string { 
+    const { pubKey, nextSigHash } = SpendingCondition.nextVerification(
+      initialSigHash,
+      authType,
+      this.fee!,
+      this.nonce!,
+      this.pubKeyEncoding!,
+      this.signature!,
+    )
+    
+    // TODO: verify pub key
+
+    return nextSigHash;
   }
 
   numSignatures(): number {
@@ -285,28 +355,77 @@ export class MultiSigSpendingCondition extends SpendingCondition {
 export class Authorization extends Deserializable {
   authType?: AuthType;
   spendingCondition?: SpendingCondition;
+  sponsorSpendingCondition?: SpendingCondition;
 
-  constructor(authType?: AuthType, spendingConditions?: SpendingCondition) {
+  constructor(
+    authType?: AuthType, 
+    spendingConditions?: SpendingCondition, 
+    sponsorSpendingCondition?: SpendingCondition
+  ) {
     super();
     this.authType = authType;
     this.spendingCondition = spendingConditions;
+    this.sponsorSpendingCondition = sponsorSpendingCondition;
   }
 
   intoInitialSighashAuth(): Authorization {
-    if (this.authType === AuthType.Standard) {
-      return new Authorization(AuthType.Standard, this.spendingCondition?.clear());
-    } else {
-      return new Authorization(AuthType.Sponsored, this.spendingCondition?.clear());
+    switch (this.authType) {
+      case AuthType.Standard:
+        return new Authorization(AuthType.Standard, this.spendingCondition?.clear());
+      case AuthType.Sponsored:
+        const auth = new Authorization(
+          AuthType.Sponsored, 
+          this.spendingCondition?.clear(), 
+          SpendingCondition.newInitialSigHash()
+        );
+        return auth;
+      default:
+        throw new SigningError('Unexpected authorization type for signing');
     }
   }
 
   setFee(amount: BigNum) {
-    this.spendingCondition!.fee = amount;
+    switch (this.authType) {
+      case AuthType.Standard:
+        this.spendingCondition!.fee = amount;
+        break;
+      case AuthType.Sponsored:
+        this.sponsorSpendingCondition!.fee = amount;
+        break;
+    }
+  }
+
+  getFee() {
+    switch (this.authType) {
+      case AuthType.Standard:
+        return this.spendingCondition!.fee;
+      case AuthType.Sponsored:
+        return this.sponsorSpendingCondition!.fee;
+    }
   }
 
   setNonce(nonce: BigNum) {
     this.spendingCondition!.nonce = nonce;
   }
+
+  setSponsorNonce(nonce: BigNum) {
+    this.sponsorSpendingCondition!.nonce = nonce;
+  }
+
+  setSponsor(sponsorSpendingCondition: SpendingCondition) {
+    this.sponsorSpendingCondition = sponsorSpendingCondition;
+  }
+
+  verifyOrigin(initialSigHash: string): string {
+    switch( this.authType) {
+      case AuthType.Standard:
+        return this.spendingCondition!.verify(initialSigHash, AuthType.Standard);
+      case AuthType.Sponsored:
+        return this.spendingCondition!.verify(initialSigHash, AuthType.Standard);
+      default: 
+        throw new SigningError('Invalid origin auth type');
+    }
+}
 
   serialize(): Buffer {
     const bufferArray: BufferArray = new BufferArray();
@@ -323,8 +442,15 @@ export class Authorization extends Deserializable {
         bufferArray.push(this.spendingCondition.serialize());
         break;
       case AuthType.Sponsored:
-        // TODO
-        throw new SerializationError('Not yet implemented: serializing sponsored transactions');
+        if (this.spendingCondition === undefined) {
+          throw new SerializationError('"spendingCondition" is undefined');
+        }
+        if (this.sponsorSpendingCondition === undefined) {
+          throw new SerializationError('"spendingCondition" is undefined');
+        }
+        bufferArray.push(this.spendingCondition.serialize());
+        bufferArray.push(this.sponsorSpendingCondition.serialize());
+        break;
       default:
         throw new SerializationError(
           `Unexpected transaction AuthType while serializing: ${this.authType}`
@@ -344,8 +470,10 @@ export class Authorization extends Deserializable {
         this.spendingCondition = SpendingCondition.deserialize(bufferReader);
         break;
       case AuthType.Sponsored:
-        // TODO
-        throw new DeserializationError('Not yet implemented: deserializing sponsored transactions');
+        this.spendingCondition = SpendingCondition.deserialize(bufferReader);
+        this.sponsorSpendingCondition = SpendingCondition.deserialize(bufferReader);
+        break;
+        // throw new DeserializationError('Not yet implemented: deserializing sponsored transactions');
       default:
         throw new DeserializationError(
           `Unexpected transaction AuthType while deserializing: ${this.authType}`
@@ -361,7 +489,19 @@ export class StandardAuthorization extends Authorization {
 }
 
 export class SponsoredAuthorization extends Authorization {
-  constructor(spendingCondition: SpendingCondition) {
-    super(AuthType.Sponsored, spendingCondition);
+  constructor(
+    originSpendingCondition: SpendingCondition, 
+    sponsorSpendingCondition?: SpendingCondition
+  ) {
+    var sponsorSC = sponsorSpendingCondition;
+    if (!sponsorSC) {
+      sponsorSC = new SpendingCondition(
+        AddressHashMode.SerializeP2PKH, 
+        "0".repeat(66),
+        new BigNum(0),
+        new BigNum(0)
+      )
+    }
+    super(AuthType.Sponsored, originSpendingCondition, sponsorSC);
   }
 }

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -947,6 +947,12 @@ export async function sponsorTransaction(
       case PayloadType.ContractCall:
         txFee = await estimateContractFunctionCall(options.transaction, network);
         break;
+      default:
+        throw new Error(
+          `Spnsored transactions not supported for transaction type ${
+            PayloadType[options.transaction.payload.payloadType]
+          }`
+        );
     }
     options.transaction.setFee(txFee);
     options.fee = txFee;

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -8,11 +8,11 @@ import {
   createContractCallPayload,
 } from './payload';
 
-import { 
-  SingleSigSpendingCondition, 
-  StandardAuthorization, 
+import {
+  SingleSigSpendingCondition,
+  StandardAuthorization,
   SponsoredAuthorization,
-  SpendingCondition 
+  SpendingCondition,
 } from './authorization';
 
 import {
@@ -274,7 +274,7 @@ export async function makeSTXTokenTransfer(
   const addressHashMode = AddressHashMode.SerializeP2PKH;
   const privKey = createStacksPrivateKey(options.senderKey);
   const pubKey = getPublicKey(privKey);
-  var authorization = null;
+  let authorization = null;
 
   const spendingCondition = new SingleSigSpendingCondition(
     addressHashMode,
@@ -433,7 +433,7 @@ export async function makeContractDeploy(
   const privKey = createStacksPrivateKey(options.senderKey);
   const pubKey = getPublicKey(privKey);
 
-  var authorization = null;
+  let authorization = null;
 
   const spendingCondition = new SingleSigSpendingCondition(
     addressHashMode,
@@ -615,7 +615,7 @@ export async function makeContractCall(txOptions: ContractCallOptions): Promise<
   const privKey = createStacksPrivateKey(options.senderKey);
   const pubKey = getPublicKey(privKey);
 
-  var authorization = null;
+  let authorization = null;
 
   const spendingCondition = new SingleSigSpendingCondition(
     addressHashMode,
@@ -926,12 +926,14 @@ export async function sponsorTransaction(
   };
 
   const options = Object.assign(defaultOptions, sponsorOptions);
-  const network = options.transaction.version === TransactionVersion.Mainnet 
-    ? new StacksMainnet() : new StacksTestnet()
+  const network =
+    options.transaction.version === TransactionVersion.Mainnet
+      ? new StacksMainnet()
+      : new StacksTestnet();
   const sponsorPubKey = pubKeyfromPrivKey(options.sponsorPrivateKey);
 
   if (!sponsorOptions.fee) {
-    var txFee = new BigNum(0);
+    let txFee = new BigNum(0);
     switch (options.transaction.payload.payloadType) {
       case PayloadType.TokenTransfer:
         txFee = await estimateTransfer(options.transaction, network);
@@ -942,7 +944,7 @@ export async function sponsorTransaction(
       case PayloadType.ContractCall:
         txFee = await estimateContractFunctionCall(options.transaction, network);
         break;
-    }      
+    }
     options.transaction.setFee(txFee);
     options.fee = txFee;
   }
@@ -952,24 +954,24 @@ export async function sponsorTransaction(
       network.version === TransactionVersion.Mainnet
         ? AddressVersion.MainnetSingleSig
         : AddressVersion.TestnetSingleSig;
-    
+
     const senderAddress = publicKeyToAddress(addressVersion, sponsorPubKey);
     const sponsorNonce = await getNonce(senderAddress, network);
     options.sponsorNonce = sponsorNonce;
   }
-  
+
   const sponsorSpendingCondition = new SingleSigSpendingCondition(
     options.sponsorAddressHashmode,
     publicKeyToString(sponsorPubKey),
     options.sponsorNonce,
-    options.fee,
+    options.fee
   );
-  
+
   options.transaction.setSponsor(sponsorSpendingCondition);
-  
+
   const privKey = createStacksPrivateKey(options.sponsorPrivateKey);
   const signer = TransactionSigner.createSponsorSigner(
-    options.transaction, 
+    options.transaction,
     sponsorSpendingCondition
   );
   signer.signSponsor(privKey);

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -898,6 +898,7 @@ export async function callReadOnlyFunction(
  * @param  {BigNum} fee - the transaction fee amount to sponsor
  * @param  {BigNum} sponsorNonce - the nonce of the sponsor account
  * @param  {AddressHashMode} sponsorAddressHashmode - the sponsor address hashmode
+ * @param  {StacksNetwork} network - the Stacks blockchain network this transaction is destined for
  */
 export interface SponsorOptions {
   transaction: StacksTransaction;
@@ -905,6 +906,7 @@ export interface SponsorOptions {
   fee?: BigNum;
   sponsorNonce?: BigNum;
   sponsorAddressHashmode?: AddressHashMode;
+  network?: StacksNetwork;
 }
 
 /**
@@ -927,9 +929,10 @@ export async function sponsorTransaction(
 
   const options = Object.assign(defaultOptions, sponsorOptions);
   const network =
-    options.transaction.version === TransactionVersion.Mainnet
+    sponsorOptions.network ??
+    (options.transaction.version === TransactionVersion.Mainnet
       ? new StacksMainnet()
-      : new StacksTestnet();
+      : new StacksTestnet());
   const sponsorPubKey = pubKeyfromPrivKey(options.sponsorPrivateKey);
 
   if (!sponsorOptions.fee) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-export class SerializationError extends Error {
+export class StacksTransactionError extends Error {
   constructor(message: string) {
     super(message);
     this.message = message;
@@ -9,24 +9,10 @@ export class SerializationError extends Error {
   }
 }
 
-export class DeserializationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.message = message;
-    this.name = this.constructor.name;
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
-  }
-}
+export class SerializationError extends StacksTransactionError {}
 
-export class NotImplementedError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.message = message;
-    this.name = this.constructor.name;
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
-  }
-}
+export class DeserializationError extends StacksTransactionError {}
+
+export class NotImplementedError extends StacksTransactionError {}
+
+export class SigningError extends StacksTransactionError {}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -41,7 +41,18 @@ export class NotImplementedError extends Error {
     }
   }
 }
+
 export class SigningError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.message = message;
+    this.name = this.constructor.name;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}
+export class VerificationError extends Error {
   constructor(message: string) {
     super(message);
     this.message = message;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,10 +9,45 @@ export class StacksTransactionError extends Error {
   }
 }
 
-export class SerializationError extends StacksTransactionError {}
+export class SerializationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.message = message;
+    this.name = this.constructor.name;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}
 
-export class DeserializationError extends StacksTransactionError {}
+export class DeserializationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.message = message;
+    this.name = this.constructor.name;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}
 
-export class NotImplementedError extends StacksTransactionError {}
-
-export class SigningError extends StacksTransactionError {}
+export class NotImplementedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.message = message;
+    this.name = this.constructor.name;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}
+export class SigningError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.message = message;
+    this.name = this.constructor.name;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -62,13 +62,18 @@ export function createStacksPublicKey(key: string): StacksPublicKey {
 
 export function publicKeyFromSignature(message: string, signature: MessageSignature) {
   const ec = new EC('secp256k1');
-  const messageBN = ec.keyFromPrivate(message, "hex").getPrivate().toString(10);
+  const messageBN = ec.keyFromPrivate(message, 'hex').getPrivate().toString(10);
 
   const parsedSignature = parseRecoverableSignature(signature.toString());
 
-  const publicKey = ec.recoverPubKey(messageBN, parsedSignature, parsedSignature.recoveryParam, 'hex');
+  const publicKey = ec.recoverPubKey(
+    messageBN,
+    parsedSignature,
+    parsedSignature.recoveryParam,
+    'hex'
+  );
 
-  return publicKey.encodeCompressed("hex");
+  return publicKey.encodeCompressed('hex');
 }
 
 export function publicKeyFromBuffer(data: Buffer): StacksPublicKey {
@@ -176,7 +181,7 @@ export function parseRecoverableSignature(signature: string) {
     recoveryParam: hexStringToInt(recoveryParamHex),
     r,
     s,
-  }
+  };
 }
 
 export function getPublicKey(privateKey: StacksPrivateKey): StacksPublicKey {

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -23,7 +23,6 @@ import { BufferReader } from './bufferReader';
 import { AddressVersion } from './constants';
 import { c32address } from 'c32check';
 import { addressHashModeToVersion, addressToString, addressFromVersionHash } from '.';
-import { sign } from 'crypto';
 
 export interface StacksPublicKey {
   readonly type: StacksMessageType.PublicKey;

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -13,6 +13,7 @@ import {
   randomBytes,
   hash160,
   hash_p2pkh,
+  hexStringToInt,
 } from './utils';
 
 import { ec as EC } from 'elliptic';
@@ -22,6 +23,7 @@ import { BufferReader } from './bufferReader';
 import { AddressVersion } from './constants';
 import { c32address } from 'c32check';
 import { addressHashModeToVersion, addressToString, addressFromVersionHash } from '.';
+import { sign } from 'crypto';
 
 export interface StacksPublicKey {
   readonly type: StacksMessageType.PublicKey;
@@ -56,6 +58,17 @@ export function createStacksPublicKey(key: string): StacksPublicKey {
     type: StacksMessageType.PublicKey,
     data: Buffer.from(key, 'hex'),
   };
+}
+
+export function publicKeyFromSignature(message: string, signature: MessageSignature) {
+  const ec = new EC('secp256k1');
+  const messageBN = ec.keyFromPrivate(message, "hex").getPrivate().toString(10);
+
+  const parsedSignature = parseRecoverableSignature(signature.toString());
+
+  const publicKey = ec.recoverPubKey(messageBN, parsedSignature, parsedSignature.recoveryParam, 'hex');
+
+  return publicKey.encodeCompressed("hex");
 }
 
 export function publicKeyFromBuffer(data: Buffer): StacksPublicKey {
@@ -138,7 +151,32 @@ export function signWithKey(privateKey: StacksPrivateKey, input: string): Messag
   const recoveryParam = intToHexString(signature.recoveryParam, 1);
   const recoverableSignatureString = recoveryParam + r + s;
   const recoverableSignature = new MessageSignature(recoverableSignatureString);
+
   return recoverableSignature;
+}
+
+export function getSignatureRecoveryParam(signature: string) {
+  const coordinateValueBytes = 32;
+  if (signature.length < coordinateValueBytes * 2 * 2 + 1) {
+    throw new Error('Invalid signature');
+  }
+  const recoveryParamHex = signature.substr(0, 2);
+  return hexStringToInt(recoveryParamHex);
+}
+
+export function parseRecoverableSignature(signature: string) {
+  const coordinateValueBytes = 32;
+  if (signature.length < coordinateValueBytes * 2 * 2 + 1) {
+    throw new Error('Invalid signature');
+  }
+  const recoveryParamHex = signature.substr(0, 2);
+  const r = signature.substr(2, coordinateValueBytes * 2);
+  const s = signature.substr(2 + coordinateValueBytes * 2, coordinateValueBytes * 2);
+  return {
+    recoveryParam: hexStringToInt(recoveryParamHex),
+    r,
+    s,
+  }
 }
 
 export function getPublicKey(privateKey: StacksPrivateKey): StacksPublicKey {

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -48,7 +48,9 @@ export class TransactionSigner {
       throw new SigningError('"transaction.auth.spendingCondition" is undefined');
     }
     if (this.transaction.auth.spendingCondition.signaturesRequired === undefined) {
-      throw new SigningError('"transaction.auth.spendingCondition.signaturesRequired" is undefined');
+      throw new SigningError(
+        '"transaction.auth.spendingCondition.signaturesRequired" is undefined'
+      );
     }
 
     if (
@@ -71,7 +73,9 @@ export class TransactionSigner {
       throw new SigningError('"transaction.auth.spendingCondition" is undefined');
     }
     if (this.transaction.auth.sponsorSpendingCondition.signaturesRequired === undefined) {
-      throw new SigningError('"transaction.auth.spendingCondition.signaturesRequired" is undefined');
+      throw new SigningError(
+        '"transaction.auth.spendingCondition.signaturesRequired" is undefined'
+      );
     }
 
     if (

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -82,7 +82,7 @@ export class TransactionSigner {
       throw new Error('Sponsor would have too many signatures');
     }
 
-    const nextSighash = this.transaction.signNextSponsor(this.sigHash, privateKey);    
+    const nextSighash = this.transaction.signNextSponsor(this.sigHash, privateKey);
     this.sigHash = nextSighash;
     this.originDone = true;
   }

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -38,17 +38,17 @@ export class TransactionSigner {
 
   signOrigin(privateKey: StacksPrivateKey) {
     if (this.checkOverlap && this.originDone) {
-      throw Error('Cannot sign origin after sponsor key');
+      throw new SigningError('Cannot sign origin after sponsor key');
     }
 
     if (this.transaction.auth === undefined) {
-      throw new Error('"transaction.auth" is undefined');
+      throw new SigningError('"transaction.auth" is undefined');
     }
     if (this.transaction.auth.spendingCondition === undefined) {
-      throw new Error('"transaction.auth.spendingCondition" is undefined');
+      throw new SigningError('"transaction.auth.spendingCondition" is undefined');
     }
     if (this.transaction.auth.spendingCondition.signaturesRequired === undefined) {
-      throw new Error('"transaction.auth.spendingCondition.signaturesRequired" is undefined');
+      throw new SigningError('"transaction.auth.spendingCondition.signaturesRequired" is undefined');
     }
 
     if (
@@ -56,7 +56,7 @@ export class TransactionSigner {
       this.transaction.auth.spendingCondition.numSignatures() >=
         this.transaction.auth.spendingCondition.signaturesRequired
     ) {
-      throw new Error('Origin would have too many signatures');
+      throw new SigningError('Origin would have too many signatures');
     }
 
     const nextSighash = this.transaction.signNextOrigin(this.sigHash, privateKey);
@@ -65,13 +65,13 @@ export class TransactionSigner {
 
   signSponsor(privateKey: StacksPrivateKey) {
     if (this.transaction.auth === undefined) {
-      throw new Error('"transaction.auth" is undefined');
+      throw new SigningError('"transaction.auth" is undefined');
     }
     if (this.transaction.auth.sponsorSpendingCondition === undefined) {
-      throw new Error('"transaction.auth.spendingCondition" is undefined');
+      throw new SigningError('"transaction.auth.spendingCondition" is undefined');
     }
     if (this.transaction.auth.sponsorSpendingCondition.signaturesRequired === undefined) {
-      throw new Error('"transaction.auth.spendingCondition.signaturesRequired" is undefined');
+      throw new SigningError('"transaction.auth.spendingCondition.signaturesRequired" is undefined');
     }
 
     if (
@@ -79,7 +79,7 @@ export class TransactionSigner {
       this.transaction.auth.sponsorSpendingCondition.numSignatures() >=
         this.transaction.auth.sponsorSpendingCondition.signaturesRequired
     ) {
-      throw new Error('Sponsor would have too many signatures');
+      throw new SigningError('Sponsor would have too many signatures');
     }
 
     const nextSighash = this.transaction.signNextSponsor(this.sigHash, privateKey);

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -1,6 +1,9 @@
 import { StacksTransaction } from './transaction';
-
 import { StacksPrivateKey } from './keys';
+import * as _ from 'lodash';
+import { SpendingCondition } from './authorization';
+import { AuthType } from './constants';
+import { SigningError } from './errors';
 
 export class TransactionSigner {
   transaction: StacksTransaction;
@@ -15,6 +18,22 @@ export class TransactionSigner {
     this.originDone = false;
     this.checkOversign = true;
     this.checkOverlap = true;
+  }
+
+  static createSponsorSigner(transaction: StacksTransaction, spendingCondition: SpendingCondition) {
+    if (transaction.auth.authType != AuthType.Sponsored) {
+      throw new SigningError('Cannot add sponsor to non-sponsored transaction');
+    }
+
+    const tx: StacksTransaction = _.cloneDeep(transaction);
+    tx.setSponsor(spendingCondition);
+    const originSigHash = tx.verifyOrigin();
+    const signer = new this(tx);
+    signer.originDone = true;
+    signer.sigHash = originSigHash;
+    signer.checkOversign = true;
+    signer.checkOverlap = true;
+    return signer;
   }
 
   signOrigin(privateKey: StacksPrivateKey) {
@@ -42,5 +61,38 @@ export class TransactionSigner {
 
     const nextSighash = this.transaction.signNextOrigin(this.sigHash, privateKey);
     this.sigHash = nextSighash;
+  }
+
+  signSponsor(privateKey: StacksPrivateKey) {
+    if (this.transaction.auth === undefined) {
+      throw new Error('"transaction.auth" is undefined');
+    }
+    if (this.transaction.auth.sponsorSpendingCondition === undefined) {
+      throw new Error('"transaction.auth.spendingCondition" is undefined');
+    }
+    if (this.transaction.auth.sponsorSpendingCondition.signaturesRequired === undefined) {
+      throw new Error('"transaction.auth.spendingCondition.signaturesRequired" is undefined');
+    }
+
+    if (
+      this.checkOversign &&
+      this.transaction.auth.sponsorSpendingCondition.numSignatures() >=
+        this.transaction.auth.sponsorSpendingCondition.signaturesRequired
+    ) {
+      throw new Error('Sponsor would have too many signatures');
+    }
+
+    const nextSighash = this.transaction.signNextSponsor(this.sigHash, privateKey);    
+    this.sigHash = nextSighash;
+    this.originDone = true;
+  }
+
+  getTxInComplete(): StacksTransaction {
+    return _.cloneDeep(this.transaction);
+  }
+
+  resume(transaction: StacksTransaction) {
+    this.transaction = _.cloneDeep(transaction);
+    this.sigHash = transaction.signBegin();
   }
 }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -104,7 +104,12 @@ export class StacksTransaction {
     if (this.auth.authType === undefined) {
       throw new Error('"auth.authType" is undefined');
     }
-    return this.signAndAppend(this.auth.sponsorSpendingCondition, sigHash, AuthType.Sponsored, privateKey);
+    return this.signAndAppend(
+      this.auth.sponsorSpendingCondition,
+      sigHash,
+      AuthType.Sponsored,
+      privateKey
+    );
   }
 
   signAndAppend(
@@ -140,16 +145,14 @@ export class StacksTransaction {
     return txidFromData(serialized);
   }
 
-  setSponsor(
-    sponsorSpendingCondition: SpendingCondition,
-  ) {
+  setSponsor(sponsorSpendingCondition: SpendingCondition) {
     if (this.auth.authType != AuthType.Sponsored) {
       throw new SigningError('Cannot sponsor sign a non-sponsored transaction');
     }
 
     this.auth.setSponsor(sponsorSpendingCondition);
   }
-  
+
   /**
    * Set the total fee to be paid for this transaction
    *

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,8 +115,8 @@ export function createEmptyAddress(): Address {
   return {
     type: StacksMessageType.Address,
     version: AddressVersion.MainnetSingleSig,
-    hash160: "0".repeat(40),
-  }
+    hash160: '0'.repeat(40),
+  };
 }
 
 export function addressFromVersionHash(version: AddressVersion, hash: string): Address {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ import {
   exceedsMaxLengthBytes,
   hash_p2pkh,
   rightPadHexToLength,
+  hash160,
 } from './utils';
 
 import { c32addressDecode, c32address } from 'c32check';
@@ -108,6 +109,14 @@ export function createAddress(c32AddressString: string): Address {
     version: addressData[0],
     hash160: addressData[1],
   };
+}
+
+export function createEmptyAddress(): Address {
+  return {
+    type: StacksMessageType.Address,
+    version: AddressVersion.MainnetSingleSig,
+    hash160: "0".repeat(40),
+  }
 }
 
 export function addressFromVersionHash(version: AddressVersion, hash: string): Address {

--- a/tests/src/builder-tests.ts
+++ b/tests/src/builder-tests.ts
@@ -17,7 +17,14 @@ import {
   TxBroadcastResultOk,
   TxBroadcastResultRejected,
   callReadOnlyFunction,
+  sponsorTransaction,
 } from '../../src/builders';
+
+import { deserializeTransaction } from '../../src/transaction';
+
+import { TokenTransferPayload } from '../../src/payload';
+
+import { BufferReader } from '../../src/bufferReader';
 
 import { createAssetInfo } from '../../src/types';
 
@@ -27,6 +34,8 @@ import {
   NonFungibleConditionCode,
   PostConditionMode,
   TxRejectedReason,
+  AuthType,
+  AddressHashMode,
 } from '../../src/constants';
 
 import { StacksTestnet, StacksMainnet } from '../../src/network';
@@ -434,6 +443,300 @@ test('Make STX token transfer with fetch account nonce', async () => {
   expect(fetchMock.mock.calls[1][0]).toEqual(apiUrl);
   expect(fetchNonce.toNumber()).toEqual(nonce);
   expect(transaction.auth.spendingCondition?.nonce?.toNumber()).toEqual(nonce);
+});
+
+test('Make sponsored STX token transfer', async () => {
+  const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
+  const amount = new BigNum(12345);
+  const fee = new BigNum(50);
+  const nonce = new BigNum(2);
+  const senderKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01';
+  const memo = 'test memo';
+
+  const sponsorKey = '9888d734e6e80a943a6544159e31d6c7e342f695ec867d549c569fa0028892d401';
+  const sponsorFee = new BigNum(123);
+  const sponsorNonce = new BigNum(55);
+
+  const authType = AuthType.Sponsored;
+  const addressHashMode = AddressHashMode.SerializeP2PKH;
+
+  const transaction = await makeSTXTokenTransfer({
+    recipient,
+    amount,
+    senderKey,
+    fee,
+    nonce,
+    memo: memo,
+    sponsored: true
+  });
+
+  const preSponsorSerialized = transaction.serialize().toString('hex');
+  const preSponsorTx = 
+    '0000000001050015c31b8c1c11c515e244b75806bac48d1399c77500000000000000020000000000000032' +
+    '000012f0e0f7eec8657e814bdcde9352920dd9416dd757f1ada573ef268cc93001fd76db462508ffd90dec' + 
+    '57bd977c3b8517f7cbc7d31b3a80aee6068c35714f83e40029cfc6376255a78451eeb4b129ed8eacffa2fe' +
+    'ef000000000000000000000000000000000000000000000000000000000000000000000000000000000000' +
+    '00000000000000000000000000000000000000000000000000000000000000000000000000000000030200' +
+    '000000000516df0ba3e79792be7be5e50a370289accfc8c9e032000000000000303974657374206d656d6f' +
+    '00000000000000000000000000000000000000000000000000'
+
+  expect(preSponsorSerialized).toBe(preSponsorTx);
+  const sponsorOptions = {
+    transaction,
+    sponsorPrivateKey: sponsorKey,
+    fee: sponsorFee,
+    sponsorNonce,
+  }
+  
+  const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
+  const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
+
+  const bufferReader = new BufferReader(sponsorSignedTxSerialized)
+  const deserializedSponsorTx = deserializeTransaction(bufferReader);
+
+  expect(deserializedSponsorTx.auth.authType).toBe(authType);
+
+  expect(deserializedSponsorTx.auth.spendingCondition!.addressHashMode).toBe(addressHashMode);
+  expect(deserializedSponsorTx.auth.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
+  expect(deserializedSponsorTx.auth.spendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
+
+  const deserializedSponsorSpendingCondition 
+    = deserializedSponsorTx.auth.sponsorSpendingCondition!;
+  expect(deserializedSponsorSpendingCondition.addressHashMode).toBe(addressHashMode);
+  expect(deserializedSponsorSpendingCondition.nonce!.toNumber()).toBe(sponsorNonce.toNumber());
+  expect(deserializedSponsorSpendingCondition.fee!.toNumber()).toBe(sponsorFee.toNumber());
+  
+  const deserializedPayload = deserializedSponsorTx.payload as TokenTransferPayload;
+  expect(deserializedPayload.amount.toNumber()).toBe(amount.toNumber());
+});
+
+test('Make sponsored STX token transfer with sponsor fee estimate', async () => {
+  const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
+  const amount = new BigNum(12345);
+  const fee = new BigNum(50);
+  const estimateFeeRate = 2;
+  const nonce = new BigNum(2);
+  const senderKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01';
+  const memo = 'test memo';
+  const network = new StacksMainnet();
+
+  const sponsorKey = '9888d734e6e80a943a6544159e31d6c7e342f695ec867d549c569fa0028892d401';
+  const sponsorNonce = new BigNum(55);
+
+  const authType = AuthType.Sponsored;
+  const addressHashMode = AddressHashMode.SerializeP2PKH;
+
+  const transaction = await makeSTXTokenTransfer({
+    recipient,
+    amount,
+    senderKey,
+    fee,
+    nonce,
+    memo: memo,
+    sponsored: true
+  });
+
+  const sponsorFee = new BigNum(transaction.serialize().byteLength * estimateFeeRate);
+
+  const sponsorOptions = {
+    transaction,
+    sponsorPrivateKey: sponsorKey,
+    sponsorNonce,
+  }
+  
+  fetchMock.mockOnce(`${estimateFeeRate}`);
+
+  const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
+
+  expect(fetchMock.mock.calls.length).toEqual(1);
+  expect(fetchMock.mock.calls[0][0]).toEqual(network.getTransferFeeEstimateApiUrl());
+
+  const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
+
+  const bufferReader = new BufferReader(sponsorSignedTxSerialized);
+  const deserializedSponsorTx = deserializeTransaction(bufferReader);
+
+  expect(deserializedSponsorTx.auth.authType).toBe(authType);
+
+  expect(deserializedSponsorTx.auth.spendingCondition!.addressHashMode).toBe(addressHashMode);
+  expect(deserializedSponsorTx.auth.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
+  expect(deserializedSponsorTx.auth.spendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
+
+  const deserializedSponsorSpendingCondition 
+    = deserializedSponsorTx.auth.sponsorSpendingCondition!;
+  expect(deserializedSponsorSpendingCondition.addressHashMode).toBe(addressHashMode);
+  expect(deserializedSponsorSpendingCondition.nonce!.toNumber()).toBe(sponsorNonce.toNumber());
+  expect(deserializedSponsorSpendingCondition.fee!.toNumber()).toBe(sponsorFee.toNumber());
+  
+  const deserializedPayload = deserializedSponsorTx.payload as TokenTransferPayload;
+  expect(deserializedPayload.amount.toNumber()).toBe(amount.toNumber());
+});
+
+test('Make sponsored STX token transfer with set tx fee', async () => {
+  const recipient = 'ST2HQE346DED7F58Z54EJ26M2B9MQQ3JZ7RW6MXRJ';
+  const amount = new BigNum(113);
+  const fee = new BigNum(0);
+  const nonce = new BigNum(0);
+  const senderKey = '8ca861519c4fa4a08de4beaa41688f60a24b575a976cf84099f38dc099a6d74401';
+  const senderAddress = 'ST2HTEQF50SW4X8077F8RSR8WCT57QG166TVG0GCE';
+  const network = new StacksTestnet();
+
+  const sponsorKey = '9888d734e6e80a943a6544159e31d6c7e342f695ec867d549c569fa0028892d401';
+  const sponsorAddress = 'ST2TPJ3NEZ63MMJ8AY9S45HZ10QSH51YF93GE89GQ';
+  const sponsorNonce = new BigNum(0);
+  const sponsorFee = new BigNum(500);
+
+  const transaction = await makeSTXTokenTransfer({
+    recipient,
+    amount,
+    senderKey,
+    fee,
+    nonce,
+    network,
+    sponsored: true
+  });
+
+  const sponsorOptions = {
+    transaction,
+    sponsorPrivateKey: sponsorKey,
+    fee: sponsorFee,
+    sponsorNonce,
+  }
+
+  const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
+  
+  const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
+
+  const bufferReader = new BufferReader(sponsorSignedTxSerialized)
+  const deserializedSponsorTx = deserializeTransaction(bufferReader);
+
+  expect(fetchMock.mock.calls.length).toEqual(0);
+  expect(deserializedSponsorTx.auth.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
+  expect(deserializedSponsorTx.auth.spendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
+
+  const deserializedSponsorSpendingCondition 
+    = deserializedSponsorTx.auth.sponsorSpendingCondition!;
+  expect(deserializedSponsorSpendingCondition.nonce!.toNumber()).toBe(sponsorNonce.toNumber());
+  expect(deserializedSponsorSpendingCondition.fee!.toNumber()).toBe(sponsorFee.toNumber());
+  
+  const deserializedPayload = deserializedSponsorTx.payload as TokenTransferPayload;
+  expect(deserializedPayload.amount.toNumber()).toBe(amount.toNumber());
+});
+
+test('Make sponsored contract deploy with sponsor fee estimate', async () => {
+  const contractName = 'kv-store';
+  const codeBody = fs.readFileSync('./tests/src/contracts/kv-store.clar').toString();
+  const senderKey = '8ca861519c4fa4a08de4beaa41688f60a24b575a976cf84099f38dc099a6d74401';
+  const fee = new BigNum(0);
+  const nonce = new BigNum(0);
+  const network = new StacksTestnet();
+
+  const sponsorKey = '9888d734e6e80a943a6544159e31d6c7e342f695ec867d549c569fa0028892d401';
+  const sponsorAddress = 'ST2TPJ3NEZ63MMJ8AY9S45HZ10QSH51YF93GE89GQ';
+  const sponsorNonce = new BigNum(56);
+  const sponsorFee = new BigNum(4000);
+
+  const authType = AuthType.Sponsored;
+  const addressHashMode = AddressHashMode.SerializeP2PKH;
+
+  const transaction = await makeContractDeploy({
+    contractName,
+    codeBody,
+    senderKey,
+    fee,
+    nonce,
+    network,
+    sponsored: true,
+  });
+
+  const sponsorOptions = {
+    transaction,
+    sponsorPrivateKey: sponsorKey,
+    fee: sponsorFee,
+    sponsorNonce,
+  }
+  
+  const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
+
+  expect(fetchMock.mock.calls.length).toEqual(0);
+
+  const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
+
+  const bufferReader = new BufferReader(sponsorSignedTxSerialized);
+  const deserializedSponsorTx = deserializeTransaction(bufferReader);
+
+  expect(deserializedSponsorTx.auth.authType).toBe(authType);
+
+  expect(deserializedSponsorTx.auth.spendingCondition!.addressHashMode).toBe(addressHashMode);
+  expect(deserializedSponsorTx.auth.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
+  expect(deserializedSponsorTx.auth.spendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
+
+  const deserializedSponsorSpendingCondition 
+    = deserializedSponsorTx.auth.sponsorSpendingCondition!;
+  expect(deserializedSponsorSpendingCondition.addressHashMode).toBe(addressHashMode);
+  expect(deserializedSponsorSpendingCondition.nonce!.toNumber()).toBe(sponsorNonce.toNumber());
+  expect(deserializedSponsorSpendingCondition.fee!.toNumber()).toBe(sponsorFee.toNumber());
+});
+
+test('Make sponsored contract call with sponsor nonce fetch', async () => {
+  const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'kv-store';
+  const functionName = 'get-value';
+  const buffer = bufferCV(Buffer.from('foo'));
+  const senderKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
+  const nonce = new BigNum(0);
+  const network = new StacksTestnet();
+  const fee = new BigNum(0);
+  const sponsorFee = new BigNum(1000);
+
+  const sponsorKey = '9888d734e6e80a943a6544159e31d6c7e342f695ec867d549c569fa0028892d401';
+  const sponsorAddress = 'ST2TPJ3NEZ63MMJ8AY9S45HZ10QSH51YF93GE89GQ';
+  const sponsorNonce = new BigNum(55);
+
+  const authType = AuthType.Sponsored;
+  const addressHashMode = AddressHashMode.SerializeP2PKH;
+
+  const transaction = await makeContractCall({
+    contractAddress,
+    contractName,
+    functionName,
+    functionArgs: [buffer],
+    senderKey,
+    fee,
+    nonce,
+    network,
+    sponsored: true,
+  });
+
+  const sponsorOptions = {
+    transaction,
+    sponsorPrivateKey: sponsorKey,
+    fee: sponsorFee,
+  }
+  
+  fetchMock.mockOnce(`{"balance":"100000", "nonce":${sponsorNonce}}`);
+
+  const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
+
+  expect(fetchMock.mock.calls.length).toEqual(1);
+  expect(fetchMock.mock.calls[0][0]).toEqual(network.getAccountApiUrl(sponsorAddress));
+
+  const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
+
+  const bufferReader = new BufferReader(sponsorSignedTxSerialized)
+  const deserializedSponsorTx = deserializeTransaction(bufferReader);
+
+  expect(deserializedSponsorTx.auth.authType).toBe(authType);
+
+  expect(deserializedSponsorTx.auth.spendingCondition!.addressHashMode).toBe(addressHashMode);
+  expect(deserializedSponsorTx.auth.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
+  expect(deserializedSponsorTx.auth.spendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
+
+  const deserializedSponsorSpendingCondition 
+    = deserializedSponsorTx.auth.sponsorSpendingCondition!;
+  expect(deserializedSponsorSpendingCondition.addressHashMode).toBe(addressHashMode);
+  expect(deserializedSponsorSpendingCondition.nonce!.toNumber()).toBe(sponsorNonce.toNumber());
+  expect(deserializedSponsorSpendingCondition.fee!.toNumber()).toBe(sponsorFee.toNumber());
 });
 
 test('Transaction broadcast success', async () => {

--- a/tests/src/builder-tests.ts
+++ b/tests/src/builder-tests.ts
@@ -467,18 +467,18 @@ test('Make sponsored STX token transfer', async () => {
     fee,
     nonce,
     memo: memo,
-    sponsored: true
+    sponsored: true,
   });
 
   const preSponsorSerialized = transaction.serialize().toString('hex');
-  const preSponsorTx = 
+  const preSponsorTx =
     '0000000001050015c31b8c1c11c515e244b75806bac48d1399c77500000000000000020000000000000032' +
-    '000012f0e0f7eec8657e814bdcde9352920dd9416dd757f1ada573ef268cc93001fd76db462508ffd90dec' + 
+    '000012f0e0f7eec8657e814bdcde9352920dd9416dd757f1ada573ef268cc93001fd76db462508ffd90dec' +
     '57bd977c3b8517f7cbc7d31b3a80aee6068c35714f83e40029cfc6376255a78451eeb4b129ed8eacffa2fe' +
     'ef000000000000000000000000000000000000000000000000000000000000000000000000000000000000' +
     '00000000000000000000000000000000000000000000000000000000000000000000000000000000030200' +
     '000000000516df0ba3e79792be7be5e50a370289accfc8c9e032000000000000303974657374206d656d6f' +
-    '00000000000000000000000000000000000000000000000000'
+    '00000000000000000000000000000000000000000000000000';
 
   expect(preSponsorSerialized).toBe(preSponsorTx);
   const sponsorOptions = {
@@ -486,12 +486,12 @@ test('Make sponsored STX token transfer', async () => {
     sponsorPrivateKey: sponsorKey,
     fee: sponsorFee,
     sponsorNonce,
-  }
-  
+  };
+
   const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
   const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
 
-  const bufferReader = new BufferReader(sponsorSignedTxSerialized)
+  const bufferReader = new BufferReader(sponsorSignedTxSerialized);
   const deserializedSponsorTx = deserializeTransaction(bufferReader);
 
   expect(deserializedSponsorTx.auth.authType).toBe(authType);
@@ -500,12 +500,11 @@ test('Make sponsored STX token transfer', async () => {
   expect(deserializedSponsorTx.auth.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
   expect(deserializedSponsorTx.auth.spendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
 
-  const deserializedSponsorSpendingCondition 
-    = deserializedSponsorTx.auth.sponsorSpendingCondition!;
+  const deserializedSponsorSpendingCondition = deserializedSponsorTx.auth.sponsorSpendingCondition!;
   expect(deserializedSponsorSpendingCondition.addressHashMode).toBe(addressHashMode);
   expect(deserializedSponsorSpendingCondition.nonce!.toNumber()).toBe(sponsorNonce.toNumber());
   expect(deserializedSponsorSpendingCondition.fee!.toNumber()).toBe(sponsorFee.toNumber());
-  
+
   const deserializedPayload = deserializedSponsorTx.payload as TokenTransferPayload;
   expect(deserializedPayload.amount.toNumber()).toBe(amount.toNumber());
 });
@@ -533,7 +532,7 @@ test('Make sponsored STX token transfer with sponsor fee estimate', async () => 
     fee,
     nonce,
     memo: memo,
-    sponsored: true
+    sponsored: true,
   });
 
   const sponsorFee = new BigNum(transaction.serialize().byteLength * estimateFeeRate);
@@ -542,8 +541,8 @@ test('Make sponsored STX token transfer with sponsor fee estimate', async () => 
     transaction,
     sponsorPrivateKey: sponsorKey,
     sponsorNonce,
-  }
-  
+  };
+
   fetchMock.mockOnce(`${estimateFeeRate}`);
 
   const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
@@ -562,12 +561,11 @@ test('Make sponsored STX token transfer with sponsor fee estimate', async () => 
   expect(deserializedSponsorTx.auth.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
   expect(deserializedSponsorTx.auth.spendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
 
-  const deserializedSponsorSpendingCondition 
-    = deserializedSponsorTx.auth.sponsorSpendingCondition!;
+  const deserializedSponsorSpendingCondition = deserializedSponsorTx.auth.sponsorSpendingCondition!;
   expect(deserializedSponsorSpendingCondition.addressHashMode).toBe(addressHashMode);
   expect(deserializedSponsorSpendingCondition.nonce!.toNumber()).toBe(sponsorNonce.toNumber());
   expect(deserializedSponsorSpendingCondition.fee!.toNumber()).toBe(sponsorFee.toNumber());
-  
+
   const deserializedPayload = deserializedSponsorTx.payload as TokenTransferPayload;
   expect(deserializedPayload.amount.toNumber()).toBe(amount.toNumber());
 });
@@ -593,7 +591,7 @@ test('Make sponsored STX token transfer with set tx fee', async () => {
     fee,
     nonce,
     network,
-    sponsored: true
+    sponsored: true,
   });
 
   const sponsorOptions = {
@@ -601,24 +599,23 @@ test('Make sponsored STX token transfer with set tx fee', async () => {
     sponsorPrivateKey: sponsorKey,
     fee: sponsorFee,
     sponsorNonce,
-  }
+  };
 
   const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
-  
+
   const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
 
-  const bufferReader = new BufferReader(sponsorSignedTxSerialized)
+  const bufferReader = new BufferReader(sponsorSignedTxSerialized);
   const deserializedSponsorTx = deserializeTransaction(bufferReader);
 
   expect(fetchMock.mock.calls.length).toEqual(0);
   expect(deserializedSponsorTx.auth.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
   expect(deserializedSponsorTx.auth.spendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
 
-  const deserializedSponsorSpendingCondition 
-    = deserializedSponsorTx.auth.sponsorSpendingCondition!;
+  const deserializedSponsorSpendingCondition = deserializedSponsorTx.auth.sponsorSpendingCondition!;
   expect(deserializedSponsorSpendingCondition.nonce!.toNumber()).toBe(sponsorNonce.toNumber());
   expect(deserializedSponsorSpendingCondition.fee!.toNumber()).toBe(sponsorFee.toNumber());
-  
+
   const deserializedPayload = deserializedSponsorTx.payload as TokenTransferPayload;
   expect(deserializedPayload.amount.toNumber()).toBe(amount.toNumber());
 });
@@ -654,8 +651,8 @@ test('Make sponsored contract deploy with sponsor fee estimate', async () => {
     sponsorPrivateKey: sponsorKey,
     fee: sponsorFee,
     sponsorNonce,
-  }
-  
+  };
+
   const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
 
   expect(fetchMock.mock.calls.length).toEqual(0);
@@ -671,8 +668,7 @@ test('Make sponsored contract deploy with sponsor fee estimate', async () => {
   expect(deserializedSponsorTx.auth.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
   expect(deserializedSponsorTx.auth.spendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
 
-  const deserializedSponsorSpendingCondition 
-    = deserializedSponsorTx.auth.sponsorSpendingCondition!;
+  const deserializedSponsorSpendingCondition = deserializedSponsorTx.auth.sponsorSpendingCondition!;
   expect(deserializedSponsorSpendingCondition.addressHashMode).toBe(addressHashMode);
   expect(deserializedSponsorSpendingCondition.nonce!.toNumber()).toBe(sponsorNonce.toNumber());
   expect(deserializedSponsorSpendingCondition.fee!.toNumber()).toBe(sponsorFee.toNumber());
@@ -712,8 +708,8 @@ test('Make sponsored contract call with sponsor nonce fetch', async () => {
     transaction,
     sponsorPrivateKey: sponsorKey,
     fee: sponsorFee,
-  }
-  
+  };
+
   fetchMock.mockOnce(`{"balance":"100000", "nonce":${sponsorNonce}}`);
 
   const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
@@ -723,7 +719,7 @@ test('Make sponsored contract call with sponsor nonce fetch', async () => {
 
   const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
 
-  const bufferReader = new BufferReader(sponsorSignedTxSerialized)
+  const bufferReader = new BufferReader(sponsorSignedTxSerialized);
   const deserializedSponsorTx = deserializeTransaction(bufferReader);
 
   expect(deserializedSponsorTx.auth.authType).toBe(authType);
@@ -732,8 +728,7 @@ test('Make sponsored contract call with sponsor nonce fetch', async () => {
   expect(deserializedSponsorTx.auth.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
   expect(deserializedSponsorTx.auth.spendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
 
-  const deserializedSponsorSpendingCondition 
-    = deserializedSponsorTx.auth.sponsorSpendingCondition!;
+  const deserializedSponsorSpendingCondition = deserializedSponsorTx.auth.sponsorSpendingCondition!;
   expect(deserializedSponsorSpendingCondition.addressHashMode).toBe(addressHashMode);
   expect(deserializedSponsorSpendingCondition.nonce!.toNumber()).toBe(sponsorNonce.toNumber());
   expect(deserializedSponsorSpendingCondition.fee!.toNumber()).toBe(sponsorFee.toNumber());

--- a/tests/src/transaction-tests.ts
+++ b/tests/src/transaction-tests.ts
@@ -1,6 +1,10 @@
 import { StacksTransaction, deserializeTransaction } from '../../src/transaction';
 
-import { StandardAuthorization, SingleSigSpendingCondition, SponsoredAuthorization } from '../../src/authorization';
+import {
+  StandardAuthorization,
+  SingleSigSpendingCondition,
+  SponsoredAuthorization,
+} from '../../src/authorization';
 
 import { TokenTransferPayload, createTokenTransferPayload } from '../../src/payload';
 
@@ -200,16 +204,17 @@ test('Sponsored STX token transfer transaction serialization and deserialization
   const sponsorPubKey = '02b6cfeae7cdcd7ae9229e2decc7d75fe727f8dc9f0d81e58aaf46de550d8e3f58';
   const sponsorSecretKey = '3372fdabb09819bb6c9446da8a067840c81dcf8d229d048de36caac3562c5f7301';
   const spendingCondition = new SingleSigSpendingCondition(addressHashMode, pubKey, nonce, fee);
-  const sponsorSpendingCondition = new SingleSigSpendingCondition(addressHashMode, sponsorPubKey, sponsorNonce, fee);
+  const sponsorSpendingCondition = new SingleSigSpendingCondition(
+    addressHashMode,
+    sponsorPubKey,
+    sponsorNonce,
+    fee
+  );
 
   const authType = AuthType.Sponsored;
   const authorization = new SponsoredAuthorization(spendingCondition, sponsorSpendingCondition);
 
-  const transaction = new StacksTransaction(
-    transactionVersion,
-    authorization,
-    payload
-  );
+  const transaction = new StacksTransaction(transactionVersion, authorization, payload);
 
   const signer = new TransactionSigner(transaction);
   signer.signOrigin(createStacksPrivateKey(secretKey));
@@ -224,7 +229,9 @@ test('Sponsored STX token transfer transaction serialization and deserialization
   expect(deserialized.auth.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
   expect(deserialized.auth.spendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
   expect(deserialized.auth.sponsorSpendingCondition!.addressHashMode).toBe(addressHashMode);
-  expect(deserialized.auth.sponsorSpendingCondition!.nonce!.toNumber()).toBe(sponsorNonce.toNumber());
+  expect(deserialized.auth.sponsorSpendingCondition!.nonce!.toNumber()).toBe(
+    sponsorNonce.toNumber()
+  );
   expect(deserialized.auth.sponsorSpendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
   expect(deserialized.anchorMode).toBe(anchorMode);
   expect(deserialized.postConditionMode).toBe(postConditionMode);

--- a/tests/src/transaction-tests.ts
+++ b/tests/src/transaction-tests.ts
@@ -1,6 +1,6 @@
 import { StacksTransaction, deserializeTransaction } from '../../src/transaction';
 
-import { StandardAuthorization, SingleSigSpendingCondition } from '../../src/authorization';
+import { StandardAuthorization, SingleSigSpendingCondition, SponsoredAuthorization } from '../../src/authorization';
 
 import { TokenTransferPayload, createTokenTransferPayload } from '../../src/payload';
 
@@ -9,7 +9,6 @@ import { STXPostCondition, createSTXPostCondition } from '../../src/postconditio
 import { createLPList, createStandardPrincipal } from '../../src/types';
 
 import {
-  DEFAULT_CORE_NODE_API_URL,
   DEFAULT_CHAIN_ID,
   TransactionVersion,
   AnchorMode,
@@ -173,6 +172,64 @@ test('STX token transfer transaction fee setting', () => {
   expect(deserializedPostCondition.amount.toNumber()).toBe(0);
 
   const deserializedPayload = postSetFeeDeserialized.payload as TokenTransferPayload;
+  expect(deserializedPayload.recipient).toEqual(recipientCV);
+  expect(deserializedPayload.amount.toNumber()).toBe(amount.toNumber());
+});
+
+test('Sponsored STX token transfer transaction serialization and deserialization', () => {
+  const transactionVersion = TransactionVersion.Testnet;
+  const chainId = DEFAULT_CHAIN_ID;
+
+  const anchorMode = AnchorMode.Any;
+  const postConditionMode = PostConditionMode.Deny;
+
+  const address = 'SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159';
+  const recipient = createStandardPrincipal(address);
+  const recipientCV = standardPrincipalCV(address);
+  const amount = new BigNum(2500000);
+  const memo = 'memo (not included';
+
+  const payload = createTokenTransferPayload(recipientCV, amount, memo);
+
+  const addressHashMode = AddressHashMode.SerializeP2PKH;
+  const nonce = new BigNum(0);
+  const sponsorNonce = new BigNum(123);
+  const fee = new BigNum(0);
+  const pubKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
+  const secretKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01';
+  const sponsorPubKey = '02b6cfeae7cdcd7ae9229e2decc7d75fe727f8dc9f0d81e58aaf46de550d8e3f58';
+  const sponsorSecretKey = '3372fdabb09819bb6c9446da8a067840c81dcf8d229d048de36caac3562c5f7301';
+  const spendingCondition = new SingleSigSpendingCondition(addressHashMode, pubKey, nonce, fee);
+  const sponsorSpendingCondition = new SingleSigSpendingCondition(addressHashMode, sponsorPubKey, sponsorNonce, fee);
+
+  const authType = AuthType.Sponsored;
+  const authorization = new SponsoredAuthorization(spendingCondition, sponsorSpendingCondition);
+
+  const transaction = new StacksTransaction(
+    transactionVersion,
+    authorization,
+    payload
+  );
+
+  const signer = new TransactionSigner(transaction);
+  signer.signOrigin(createStacksPrivateKey(secretKey));
+  signer.signSponsor(createStacksPrivateKey(sponsorSecretKey));
+
+  const serialized = transaction.serialize();
+  const deserialized = deserializeTransaction(new BufferReader(serialized));
+  expect(deserialized.version).toBe(transactionVersion);
+  expect(deserialized.chainId).toBe(chainId);
+  expect(deserialized.auth.authType).toBe(authType);
+  expect(deserialized.auth.spendingCondition!.addressHashMode).toBe(addressHashMode);
+  expect(deserialized.auth.spendingCondition!.nonce!.toNumber()).toBe(nonce.toNumber());
+  expect(deserialized.auth.spendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
+  expect(deserialized.auth.sponsorSpendingCondition!.addressHashMode).toBe(addressHashMode);
+  expect(deserialized.auth.sponsorSpendingCondition!.nonce!.toNumber()).toBe(sponsorNonce.toNumber());
+  expect(deserialized.auth.sponsorSpendingCondition!.fee!.toNumber()).toBe(fee.toNumber());
+  expect(deserialized.anchorMode).toBe(anchorMode);
+  expect(deserialized.postConditionMode).toBe(postConditionMode);
+
+  const deserializedPayload = deserialized.payload as TokenTransferPayload;
   expect(deserializedPayload.recipient).toEqual(recipientCV);
   expect(deserializedPayload.amount.toNumber()).toBe(amount.toNumber());
 });


### PR DESCRIPTION
This PR will enable the construction of sponsored transactions where a second "sponsor" signer can pay the fees of a transaction signed by the origin. 

To create a transaction that can be sponsored, set `sponsored = true` in the transaction builder options:

```javascript
const txOptions = {
  contractAddress: 'SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X',
  contractName: 'contract_name',
  functionName: 'contract_function',
  functionArgs: [bufferCVFromString('foo')],
  senderKey: 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01',
  sponsored: true,
};

const transaction = await makeContractCall(txOptions);
const serializedTx = transaction.serialize().toString('hex'); 
```

Next, pass the serialized transaction to the sponsoring party and use the `sponsorTransaction` builder function to complete the transaction. 

```javascript
// We need to deserialize the transaction first
const bufferReader = new BufferReader(Buffer.from(serializedTx));
const deserializedTx = deserializeTransaction(bufferReader);
const sponsorKey = 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01';
// The sponsor sets the fee
// If not set, the fee will be automatically estimated like a non-sponsored transaction
const fee = BigNum(1000);
const sponsorNonce = BigNum(12);

const sponsorOptions = {
  transaction: deserializedTx,
  sponsorPrivateKey: sponsorKey,
  fee,
  sponsorNonce,
}

const sponsoredTx = await sponsorTransaction(sponsorOptions);
broadcastTransaction(sponsoredTx, network);
```

https://github.com/blockstack/stacks-transactions-js/issues/7


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
Yes

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
