### PR TITLE
feat: expose PostCondition & builders

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,13 @@ export {
   CoinbasePayload,
 } from './payload';
 
+export {
+  PostCondition,
+  createFungiblePostCondition,
+  createNonFungiblePostCondition,
+  createSTXPostCondition,
+} from './postcondition';
+
 export * from './clarity';
 export * from './keys';
 export * from './builders';


### PR DESCRIPTION
Exposes a few things from `postconditions.ts`. This is used in blockstack/ux#301, which supports passing post conditions with Connect. The authenticator needs the `PostCondition` type, and client apps might need the post condition builders.