### PR TITLE
fix: return response as json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/stacks-transactions",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Javascript library for constructing transactions on the Stacks blockchain.",
   "main": "lib/index",
   "types": "lib/index.d.ts",

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -169,7 +169,11 @@ export async function broadcastRawTransaction(
     }
   }
 
-  return await response.text();
+  try {
+    return await response.clone().json();
+  } catch (e) {
+    return await response.clone().text();
+  }
 }
 
 /**


### PR DESCRIPTION
Ran into the slightly confusing functionality that the `broadcastTransaction` function returns the txid prequoted.

i.e. 
`"f2754bbc5d6b041d220c759b5b9b05dc0b09337959ebb725fb1ab12ac9928c3d"`
not
`f2754bbc5d6b041d220c759b5b9b05dc0b09337959ebb725fb1ab12ac9928c3d`

Any reason we specifically need `.text()` call here? I could `JSON.parse` it, of course, though unless there's a reason not to, think it's nicer to return the id directly.

Also curious if there's any reason not to have the hex encoded version with the leading `0x`? Txids returned from sidecar have this prefix and I need to compare them. 

Edit: need to use `.clone()` per this issue https://github.com/node-fetch/node-fetch/issues/533