### PR TITLE
feat: add ability to create unsigned txs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ export {
   createSTXPostCondition,
 } from './postcondition';
 
+export { exceedsMaxLengthBytes } from './utils';
+
 export * from './clarity';
 export * from './keys';
 export * from './builders';

--- a/tests/src/builder-tests.ts
+++ b/tests/src/builder-tests.ts
@@ -412,6 +412,32 @@ test('Estimate token transfer fee', async () => {
   expect(resultEstimateFee2.toNumber()).toEqual(estimateFee.toNumber());
 });
 
+test(`${makeSTXTokenTransfer.name} allows *either* senderKey or publicKey`, async () => {
+  const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
+  const amount = new BigNum(12345);
+  const fee = new BigNum(0);
+  const network = new StacksTestnet();
+
+  const senderKey = 'cb3df38053d132895220b9ce471f6b676db5b9bf0b4adefb55f2118ece2478df01';
+  const publicKey = Buffer.from([]);
+
+  const args = { recipient, amount, publicKey, senderKey, fee, network };
+  await expect(makeSTXTokenTransfer(args)).rejects.toThrowError();
+});
+
+test(`${makeSTXTokenTransfer.name} ensures undefined optional properties are not allow`, async () => {
+  const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
+  const amount = new BigNum(12345);
+  const fee = new BigNum(0);
+  const network = new StacksTestnet();
+  const senderKey = 'cb3df38053d132895220b9ce471f6b676db5b9bf0b4adefb55f2118ece2478df01';
+
+  const args = { recipient, amount, senderKey, fee, network, memo: undefined };
+  await expect(makeSTXTokenTransfer(args)).rejects.toThrowError(
+    'Must not pass `undefined` object properties. Omit unused properties.'
+  );
+});
+
 test('Make STX token transfer with fetch account nonce', async () => {
   const nonce = 123;
   const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "sourceMap": true,
     "outDir": "lib",
     "esModuleInterop": false,
-    "allowSyntheticDefaultImports": false,
+    "allowSyntheticDefaultImports": false
   },
   "include": [
     "src/index.ts",


### PR DESCRIPTION
Related https://github.com/blockstack/stacks-transactions-js/issues/112

This PR introduces additional options to `makeSTXTokenTransfer()` allowing you to pass public key rather than private, so an unsigned transaction can be created.

Wanted to type this in a way the compiler can detect either `senderKey` or `publicKey`, as below, but this approach doesn't work as the compiler throws an error when checking if the prop of the other exists. For now, I've added a runtime exception if both keys are passed.

```ts
export interface BaseTokenTransferOptions {
  recipient: string | PrincipalCV;
  amount: BigNum;
  fee?: BigNum;
  nonce?: BigNum;
  network?: StacksNetwork;
  anchorMode?: AnchorMode;
  memo?: string;
  postConditionMode?: PostConditionMode;
  postConditions?: PostCondition[];
  sponsored?: boolean;
}
export interface SignedTokenTransferOptions extends BaseTokenTransferOptions {
  senderKey: string | Buffer;
}

export interface UnsignedTokenTransferOptions extends BaseTokenTransferOptions {
  publicKey: string | Buffer;
}

export type TokenTransferOptions = SignedTokenTransferOptions | UnsignedTokenTransferOptions;
```

This error follows an `if (options.senderKey) {}`

```
Property 'senderKey' does not exist on type 'Required<SignedTokenTransferOptions> | Required<UnsignedTokenTransferOptions>'.
  Property 'senderKey' does not exist on type 'Required<UnsignedTokenTransferOptions>'.ts(2339)
```
