### PR TITLE
feat: Clarity Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Multi-Sig (P2SH) transaction support
+- Support for clarity string types
 
 ## v0.6.1
 - Fixed `BufferArray` class so that it does not need to rely on extending the Array native class

--- a/src/clarity/clarityValue.ts
+++ b/src/clarity/clarityValue.ts
@@ -10,7 +10,10 @@ import {
   ResponseOkCV,
   ListCV,
   TupleCV,
+  StringAsciiCV,
+  StringUtf8CV,
 } from '.';
+
 import { principalToString } from './types/principalCV';
 import { CLARITY_INT_SIZE } from '../constants';
 import { isClarityName } from '../utils';
@@ -33,6 +36,8 @@ export enum ClarityType {
   OptionalSome = 0x0a,
   List = 0x0b,
   Tuple = 0x0c,
+  StringASCII = 0x0d,
+  StringUTF8 = 0x0e,
 }
 
 export type ClarityValue =
@@ -46,7 +51,9 @@ export type ClarityValue =
   | ResponseErrorCV
   | ResponseOkCV
   | ListCV
-  | TupleCV;
+  | TupleCV
+  | StringAsciiCV
+  | StringUtf8CV;
 
 export function cvToString(val: ClarityValue, encoding: 'tryAscii' | 'hex' = 'tryAscii'): string {
   switch (val.type) {
@@ -83,6 +90,10 @@ export function cvToString(val: ClarityValue, encoding: 'tryAscii' | 'hex' = 'tr
       return `(tuple ${Object.keys(val.data)
         .map(key => `(${key} ${cvToString(val.data[key], encoding)})`)
         .join(' ')})`;
+    case ClarityType.StringASCII:
+      return `"${val.data}"`;
+    case ClarityType.StringUTF8:
+      return `u"${val.data}"`;
   }
 }
 
@@ -114,5 +125,9 @@ export function getCVTypeString(val: ClarityValue): string {
       return `(tuple ${Object.keys(val.data)
         .map(key => `(${key} ${getCVTypeString(val.data[key])})`)
         .join(' ')})`;
+    case ClarityType.StringASCII:
+      return `(string-ascii ${Buffer.from(val.data, 'ascii').length})`;
+    case ClarityType.StringUTF8:
+      return `(string-utf8 ${Buffer.from(val.data, 'utf8').length})`;
   }
 }

--- a/src/clarity/deserialize.ts
+++ b/src/clarity/deserialize.ts
@@ -18,6 +18,7 @@ import {
 import { BufferReader } from '../bufferReader';
 import { deserializeAddress, deserializeLPString } from '../types';
 import { DeserializationError } from '../errors';
+import { stringAsciiCV, stringUtf8CV } from './types/stringCV';
 
 export default function deserializeCV(buffer: BufferReader | Buffer): ClarityValue {
   const bufferReader = Buffer.isBuffer(buffer) ? new BufferReader(buffer) : buffer;
@@ -82,6 +83,16 @@ export default function deserializeCV(buffer: BufferReader | Buffer): ClarityVal
         tupleContents[clarityName] = deserializeCV(bufferReader);
       }
       return tupleCV(tupleContents);
+
+    case ClarityType.StringASCII:
+      const asciiStrLen = bufferReader.readUInt32BE();
+      const asciiStr = bufferReader.readBuffer(asciiStrLen).toString('ascii');
+      return stringAsciiCV(asciiStr);
+
+    case ClarityType.StringUTF8:
+      const utf8StrLen = bufferReader.readUInt32BE();
+      const utf8Str = bufferReader.readBuffer(utf8StrLen).toString('utf8');
+      return stringUtf8CV(utf8Str);
 
     default:
       throw new DeserializationError(

--- a/src/clarity/index.ts
+++ b/src/clarity/index.ts
@@ -3,6 +3,7 @@ import { BooleanCV, TrueCV, FalseCV, trueCV, falseCV } from './types/booleanCV';
 import { IntCV, UIntCV, intCV, uintCV } from './types/intCV';
 import { BufferCV, bufferCV, bufferCVFromString } from './types/bufferCV';
 import { OptionalCV, noneCV, someCV } from './types/optionalCV';
+
 import {
   ResponseCV,
   ResponseOkCV,
@@ -10,6 +11,7 @@ import {
   responseOkCV,
   responseErrorCV,
 } from './types/responseCV';
+
 import {
   StandardPrincipalCV,
   ContractPrincipalCV,
@@ -20,8 +22,10 @@ import {
   PrincipalCV,
   contractPrincipalCVFromStandard,
 } from './types/principalCV';
+
 import { ListCV, listCV } from './types/listCV';
 import { TupleCV, tupleCV } from './types/tupleCV';
+import { StringAsciiCV, StringUtf8CV, stringUtf8CV, stringAsciiCV } from './types/stringCV';
 import { serializeCV } from './serialize';
 import deserializeCV from './deserialize';
 
@@ -44,6 +48,8 @@ export {
   ContractPrincipalCV,
   ListCV,
   TupleCV,
+  StringAsciiCV,
+  StringUtf8CV,
 };
 
 // Value construction functions
@@ -65,6 +71,8 @@ export {
   contractPrincipalCVFromStandard,
   listCV,
   tupleCV,
+  stringAsciiCV,
+  stringUtf8CV,
   getCVTypeString,
 };
 

--- a/src/clarity/types/stringCV.ts
+++ b/src/clarity/types/stringCV.ts
@@ -1,0 +1,30 @@
+import { ClarityType } from '../clarityValue';
+
+interface StringAsciiCV {
+  readonly type: ClarityType.StringASCII;
+  readonly data: string;
+}
+
+interface StringUtf8CV {
+  readonly type: ClarityType.StringUTF8;
+  readonly data: string;
+}
+
+const stringAsciiCV = (data: string): StringAsciiCV => {
+  return { type: ClarityType.StringASCII, data };
+};
+
+const stringUtf8CV = (data: string): StringUtf8CV => {
+  return { type: ClarityType.StringUTF8, data };
+};
+
+const stringCV = (data: string, encoding: 'ascii' | 'utf8'): StringAsciiCV | StringUtf8CV => {
+  switch (encoding) {
+    case 'ascii':
+      return stringAsciiCV(data);
+    case 'utf8':
+      return stringAsciiCV(data);
+  }
+};
+
+export { StringAsciiCV, StringUtf8CV, stringAsciiCV, stringUtf8CV, stringCV };

--- a/tests/src/abi-tests.ts
+++ b/tests/src/abi-tests.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { createContractCallPayload } from '../../src/payload';
+
 import {
   trueCV,
   intCV,
@@ -14,7 +15,10 @@ import {
   responseOkCV,
   responseErrorCV,
   noneCV,
+  stringAsciiCV,
+  stringUtf8CV,
 } from '../../src/clarity';
+
 import {
   validateContractCall,
   ClarityAbi,
@@ -41,6 +45,8 @@ test('ABI validation', () => {
       key6: someCV(falseCV()),
       key7: responseOkCV(trueCV()),
       key8: listCV([trueCV(), falseCV()]),
+      key9: stringAsciiCV('Hello World'),
+      key10: stringUtf8CV('Hello World'),
     }),
   ];
 
@@ -94,6 +100,8 @@ test('ABI validation fail, tuple mistyped', () => {
       key6: noneCV(),
       key7: responseErrorCV(trueCV()),
       key8: falseCV(),
+      key9: stringAsciiCV('Hello World'),
+      key10: stringUtf8CV('Hello World'),
     }),
   ];
 
@@ -105,6 +113,7 @@ test('ABI validation fail, tuple mistyped', () => {
   );
 
   expect(() => validateContractCall(payload, TEST_ABI)).toThrow(
+    // Don't forget to include spaces at the end of each line of this multiline string
     oneLineTrim`
     Clarity function \`tuple-test\` expects argument 1 to be of type 
       (tuple 
@@ -115,7 +124,9 @@ test('ABI validation fail, tuple mistyped', () => {
         (key5 (buff 3)) 
         (key6 (optional bool)) 
         (key7 (response bool bool)) 
-        (key8 (list 2 bool))), not 
+        (key8 (list 2 bool)) 
+        (key9 (string-ascii 11)) 
+        (key10 (string-utf8 11))), not 
       (tuple 
         (key1 bool) 
         (key2 int) 
@@ -124,7 +135,9 @@ test('ABI validation fail, tuple mistyped', () => {
         (key5 (buff 3)) 
         (key6 (optional none)) 
         (key7 (responseError bool)) 
-        (key8 bool))`
+        (key8 bool) 
+        (key9 (string-ascii 11)) 
+        (key10 (string-utf8 11)))`
   );
 });
 
@@ -153,6 +166,7 @@ test('ABI validation fail, tuple wrong key', () => {
   );
 
   expect(() => validateContractCall(payload, TEST_ABI)).toThrow(
+    // Don't forget to include spaces at the end of each line of this multiline string
     oneLineTrim`
     Clarity function \`tuple-test\` expects argument 1 to be of type 
     (tuple 
@@ -163,7 +177,9 @@ test('ABI validation fail, tuple wrong key', () => {
       (key5 (buff 3)) 
       (key6 (optional bool)) 
       (key7 (response bool bool)) 
-      (key8 (list 2 bool))), not 
+      (key8 (list 2 bool)) 
+      (key9 (string-ascii 11)) 
+      (key10 (string-utf8 11))), not 
     (tuple 
       (wrong-key bool) 
       (key2 int) 

--- a/tests/src/abi/test-abi.json
+++ b/tests/src/abi/test-abi.json
@@ -12,7 +12,9 @@
           { "name": "key5", "type": { "buffer": { "length": 3 } } },
           { "name": "key6", "type": { "optional": "bool" } },
           { "name": "key7", "type": { "response": { "ok": "bool", "error": "bool" } } },
-          { "name": "key8", "type": { "list": { "type": "bool", "length": 2 } } }
+          { "name": "key8", "type": { "list": { "type": "bool", "length": 2 } } },
+          { "name": "key9", "type": { "string-ascii": { "length": 11 } } },
+          { "name": "key10", "type": { "string-utf8": { "length": 11 } } }
         ]}}
       ],
       "outputs": { "type": { "response": { "ok": "bool", "error": "none" } } }

--- a/tests/src/clarity-tests.ts
+++ b/tests/src/clarity-tests.ts
@@ -281,6 +281,36 @@ describe('Clarity Types', () => {
       const serialized = serializeCV(tuple).toString('hex');
       expect(serialized).toEqual('0c000000020362617a0906666f6f62617203');
     });
+
+    test('Ascii String Vector', () => {
+      const str = stringAsciiCV('hello world');
+      const serialized = serializeCV(str).toString('hex');
+      expect(serialized).toEqual('0d0000000b68656c6c6f20776f726c64');
+    });
+
+    test('Ascii String Escaped Length', () => {
+      const strings = [
+        stringAsciiCV('\\'),
+        stringAsciiCV('\"'),
+        stringAsciiCV('\n'),
+        stringAsciiCV('\t'),
+        stringAsciiCV('\r'),
+        stringAsciiCV('\0'),
+      ];
+      const serialized = strings.map(serializeCV);
+      serialized.forEach(ser => {
+        const reader = new BufferReader(ser);
+        const serializedStringLenByte = reader.readBuffer(5)[4];
+        expect(serializedStringLenByte).toEqual(1);
+        expect(ser.length).toEqual(6);
+      })
+    });
+
+    test('Utf8 String Vector', () => {
+      const str = stringUtf8CV('hello world');
+      const serialized = serializeCV(str).toString('hex');
+      expect(serialized).toEqual('0e0000000b68656c6c6f20776f726c64');
+    });
   });
 
   describe('Clarity Value To Clarity String Literal', () => {

--- a/tests/src/clarity-tests.ts
+++ b/tests/src/clarity-tests.ts
@@ -22,6 +22,10 @@ import {
   TupleCV,
   standardPrincipalCVFromAddress,
   contractPrincipalCVFromStandard,
+  stringAsciiCV,
+  StringAsciiCV,
+  stringUtf8CV,
+  StringUtf8CV,
 } from '../../src/clarity';
 import { BufferReader } from '../../src/bufferReader';
 import { cvToString } from '../../src/clarity/clarityValue';
@@ -125,6 +129,18 @@ describe('Clarity Types', () => {
         return bufA.compare(bufB);
       });
       expect(Object.keys(serializedDeserialized.data)).toEqual(lexicographic);
+    });
+
+    test('StringAsciiCV', () => {
+      const str = stringAsciiCV('hello world');
+      const serializedDeserialized = serializeDeserialize(str) as StringAsciiCV;
+      expect(serializedDeserialized).toEqual(str);
+    });
+
+    test('StringUtf8CV', () => {
+      const str = stringUtf8CV('hello world');
+      const serializedDeserialized = serializeDeserialize(str) as StringUtf8CV;
+      expect(serializedDeserialized).toEqual(str);
     });
   });
 
@@ -285,6 +301,8 @@ describe('Clarity Types', () => {
           a: trueCV(),
           b: falseCV(),
         }),
+        m: stringAsciiCV('hello world'),
+        n: stringUtf8CV('hello \u{1234}'),
       });
 
       const tupleString = cvToString(tuple);
@@ -303,7 +321,9 @@ describe('Clarity Types', () => {
           (i (ok true)) 
           (j (err false)) 
           (k (list true false)) 
-          (l (tuple (a true) (b false))))`
+          (l (tuple (a true) (b false))) 
+          (m "hello world") 
+          (n u"hello \u{1234}"))`
       );
     });
 

--- a/tests/src/clarity-tests.ts
+++ b/tests/src/clarity-tests.ts
@@ -138,7 +138,7 @@ describe('Clarity Types', () => {
     });
 
     test('StringUtf8CV', () => {
-      const str = stringUtf8CV('hello world');
+      const str = stringUtf8CV('hello 🌾');
       const serializedDeserialized = serializeDeserialize(str) as StringUtf8CV;
       expect(serializedDeserialized).toEqual(str);
     });


### PR DESCRIPTION
This PR adds support for the new [Clarity string types](https://github.com/blockstack/stacks-blockchain/pull/1779) `string-ascii` and `string-utf8`. It does so by introducing corresponding typescript interfaces (`StringAsciiCV` and `StringUtf8CV` ), constructor functions to build them, and serialization/deserialization functions. It also adds support for validating ABIs of contracts that deal with string types.

Issue: #110 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
