### PR TITLE
feat: 'addSignature' method to StacksTransaction, closes #121

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,59 +1,74 @@
 # Changelog
+
 All notable changes to the project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 ### Added
+
 - Multi-Sig (P2SH) transaction support
 - Support for clarity string types
+- Added `createTxWithSignature` method to
 
 ## v0.6.1
+
 - Fixed `BufferArray` class so that it does not need to rely on extending the Array native class
 
 ## v0.6.0
+
 - Added ability to create sponsored transactions using `sponsorTransaction()`
 
 ## v0.5.1
+
 ### Changed
+
 - `cvToString()` serializes uints with literal `"u"` prefix.
 - `PostCondition` and builders are now exported
 
 ## v0.5.0
+
 ### Changed
+
 - renamed `makeSmartContractDeploy()` to `makeContractDeploy()`
 - tx broadcast now returns a response type which may contain an error
 - fixed contract deploy auto fee estimation
 - allow buffers to be less than or equal to the size specified in the ABI when validating contract-call args
 
 ## v0.4.6
+
 - Updates the testnet network config to use stable `testnet-master.blockstack.org` URL
 
-## v0.4.5 
+## v0.4.5
+
 - Add `parseToCV()` utility function to convert string input to the appropriate Clarity value based on the Clarity ABI type specified by the contract function
 
 ## v0.4.4
 
 ### Added
+
 - Ability to broadcast raw transactions using `broadcastRawTransaction()`
 - `abiFunctionToString()` method for converting ABI function typedef to Clarity repr string
 
 ### Changed
+
 - Changed the format that the type -> string functions output to match Clarity type repr
 
-## v0.4.2 
+## v0.4.2
 
 ### Added
+
 - Add cvToString() method for converting ClarityValue objects to their string (source code) representation
 
 ### Changed
 
-## v0.4.1 
+## v0.4.1
 
 ### Added
+
 - ABI validation for contract-call transactions
 - Additional methods added to the StacksNetwork interface
 
 ### Changed
-

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -18,6 +18,7 @@ import {
   SingleSigSpendingCondition,
   MultiSigSpendingCondition,
   createTransactionAuthField,
+  createMessageSignature,
 } from './authorization';
 
 import { BufferArray, txidFromData, cloneDeep } from './utils';
@@ -87,6 +88,18 @@ export class StacksTransaction {
     const tx = cloneDeep(this);
     tx.auth = tx.auth.intoInitialSighashAuth();
     return tx.txid();
+  }
+
+  createTxWithSignature(signature: string | Buffer): StacksTransaction {
+    const parsedSig = typeof signature === 'string' ? signature : signature.toString('hex');
+    const tx = cloneDeep(this);
+    if (!tx.auth.spendingCondition) {
+      throw new Error('Cannot set signature on transaction without spending condition');
+    }
+    (tx.auth.spendingCondition as SingleSigSpendingCondition).signature = createMessageSignature(
+      parsedSig
+    );
+    return tx;
   }
 
   verifyOrigin(): string {

--- a/tests/src/builder-tests.ts
+++ b/tests/src/builder-tests.ts
@@ -49,6 +49,7 @@ import { ClarityAbi } from '../../src/contract-abi';
 import { createStacksPrivateKey, pubKeyfromPrivKey, publicKeyToString } from '../../src/keys';
 import { TransactionSigner } from '../../src/signer';
 import fetchMock from 'jest-fetch-mock';
+import { SingleSigSpendingCondition } from '../../src/authorization';
 
 beforeEach(() => {
   fetchMock.resetMocks();
@@ -257,6 +258,36 @@ test('Make Multi-Sig STX token transfer', async () => {
     '00000000000000000000000000000000000000000000000000';
 
   expect(serializedSignedTx.toString('hex')).toBe(signedTx);
+});
+
+test('addSignature to an unsigned transaction', async () => {
+  const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
+  const amount = new BigNum(2500000);
+  const fee = new BigNum(0);
+  const nonce = new BigNum(0);
+  const publicKey = '021ae7f08f9eaecaaa93f7c6ceac29213bae09588c15e2aded32016b259cfd9a1f';
+
+  const unsignedTx = await makeUnsignedSTXTokenTransfer({
+    recipient,
+    amount,
+    fee,
+    nonce,
+    publicKey,
+  });
+
+  const nullSignature = (unsignedTx.auth.spendingCondition as any).signature.data;
+
+  expect(nullSignature).toEqual(
+    '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+  );
+
+  const sig =
+    '00e4ee626905ee9d04b786e2942a69504dcc0f35ca79b86fb0aafcd47a81fc3bf1547e302c3acf5c89d935a53df334316e6fcdc203cf6bed91288ebf974385398c';
+  const signedTx = unsignedTx.createTxWithSignature(sig);
+  expect((signedTx.auth.spendingCondition as SingleSigSpendingCondition).signature.data).toEqual(
+    sig
+  );
+  expect(unsignedTx).not.toBe(signedTx);
 });
 
 test('Make smart contract deploy', async () => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,9 +4,7 @@
     "noEmit": false,
     "rootDir": "./src",
     "outDir": "./lib",
-    "declaration": true,
+    "declaration": true
   },
-  "include": [
-    "src/**/*"
-  ]
+  "include": ["src/**/*"]
 }

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -8,9 +8,7 @@
     "outDir": "lib",
     "sourceMap": true
   },
-  "include": [
-    "src",
-  ],
+  "include": ["src"],
   "typedocOptions": {
     "readme": "overview.md",
     "mode": "file",
@@ -18,7 +16,7 @@
     "excludeProtected": true,
     "excludeExternals": true,
     "excludeNotExported": false,
-    "includes" : "mdincludes",
+    "includes": "mdincludes",
     "includeDeclarations": false,
     "gitRevision": "master",
     "listInvalidSymbolLinks": true,


### PR DESCRIPTION
Example:
As a Blockstack developer, I must be able to interact with an API exposed by `StacksTransaction` to add a signature to an unsigned transaction.

This change is implemented with an immutable api. 

Is there a case in which spending condition would be `undefined`? Would be a lot cleaner if a tx were to always have one.

```typescript
const unsignedTx = makeUnsignedSTXTokenTransfer(txOptions);
const signedTx = unsignedTx.setSignature(sig);
```

See issue #121 

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
