### PR TITLE
feat: export cvToHex and parseReadOnlyResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-Sig (P2SH) transaction support
 - Support for clarity string types
 - Added `createTxWithSignature` method to
+- Added `cvToHex` and `parseReadOnlyResponse`
 
 ## v0.6.1
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,3 +30,4 @@ export * from './types';
 export * from './constants';
 export * from './contract-abi';
 export * from './signer';
+export { cvToHex, parseReadOnlyResponse } from './utils';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -156,7 +156,10 @@ export async function fetchPrivate(input: RequestInfo, init?: RequestInit): Prom
   const fetchResult = await fetch(input, fetchOpts);
   return fetchResult;
 }
-
+/**
+ * Converts a clarity value to a hex encoded string with `0x` prefix
+ * @param cv
+ */
 export function cvToHex(cv: ClarityValue) {
   const serialized = serializeCV(cv);
   return `0x${serialized.toString('hex')}`;
@@ -174,6 +177,10 @@ export interface ReadOnlyFunctionResponse {
   result: string;
 }
 
+/**
+ * Converts the response of a read-only function call into its Clarity Value
+ * @param param
+ */
 export const parseReadOnlyResponse = ({ result }: ReadOnlyFunctionResponse): ClarityValue => {
   const hex = result.slice(2);
   const bufferCV = Buffer.from(hex, 'hex');


### PR DESCRIPTION
## Description

As a blockstack developer, I would like to use the blockstack-api-client library. The method `SmartContractsApi.callReadOnlyFunction` requires to hex encode clarity values, the result of that method needs to be parsed. In  this library (`stacks-transactions-js`) these methods already exists.

These methods, defined in `utils.ts` are now exported.

For details refer to issue #126 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
Yes

## Checklist
- [x] Code is commented where needed
- [ ] ~~Unit test coverage for new or modified code paths~~
- [ ] ~~`npm run test` passes~~
- [x] Changelog is updated
- [x] Tag @yknl for review
