### PR TITLE
feat: get map entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-Sig (P2SH) transaction support
 - Support for clarity string types
 - Added `createTxWithSignature` method to
+- Added `cvToHex` and `parseReadOnlyResponse`
 
 ## v0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-Sig (P2SH) transaction support
 - Support for clarity string types
 - Added `createTxWithSignature` method to
-- Added `cvToHex` and `parseReadOnlyResponse`
+- Added `getMapEntry` method to query contract data maps
+- Added `cvToHex` and `parseReadOnlyResponse`, `parseMapEntryResponse`
 
 ## v0.6.1
 

--- a/src/clarity/index.ts
+++ b/src/clarity/index.ts
@@ -2,7 +2,7 @@ import { ClarityValue, ClarityType, getCVTypeString, cvToString } from './clarit
 import { BooleanCV, TrueCV, FalseCV, trueCV, falseCV } from './types/booleanCV';
 import { IntCV, UIntCV, intCV, uintCV } from './types/intCV';
 import { BufferCV, bufferCV, bufferCVFromString } from './types/bufferCV';
-import { OptionalCV, noneCV, someCV } from './types/optionalCV';
+import { OptionalCV, SomeCV, noneCV, someCV } from './types/optionalCV';
 
 import {
   ResponseCV,
@@ -40,6 +40,7 @@ export {
   UIntCV,
   BufferCV,
   OptionalCV,
+  SomeCV,
   ResponseCV,
   ResponseOkCV,
   ResponseErrorCV,

--- a/src/clarity/types/optionalCV.ts
+++ b/src/clarity/types/optionalCV.ts
@@ -12,7 +12,7 @@ interface SomeCV {
 }
 
 const noneCV = (): OptionalCV => ({ type: ClarityType.OptionalNone });
-const someCV = (value: ClarityValue): OptionalCV => ({ type: ClarityType.OptionalSome, value });
+const someCV = (value: ClarityValue): SomeCV => ({ type: ClarityType.OptionalSome, value });
 const optionalCVOf = (value?: ClarityValue): OptionalCV => {
   if (value) {
     return someCV(value);
@@ -21,4 +21,4 @@ const optionalCVOf = (value?: ClarityValue): OptionalCV => {
   }
 };
 
-export { OptionalCV, noneCV, someCV, optionalCVOf };
+export { OptionalCV, SomeCV, noneCV, someCV, optionalCVOf };

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,4 +30,4 @@ export * from './types';
 export * from './constants';
 export * from './contract-abi';
 export * from './signer';
-export { cvToHex, parseReadOnlyResponse } from './utils';
+export { cvToHex, parseReadOnlyResponse, parseGetMapEntryResponse } from './utils';

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,3 +30,4 @@ export * from './types';
 export * from './constants';
 export * from './contract-abi';
 export * from './signer';
+export { cvToHex, parseReadOnlyResponse } from './utils';

--- a/src/network.ts
+++ b/src/network.ts
@@ -18,6 +18,7 @@ export interface StacksNetwork {
     contractName: string,
     functionName: string
   ) => string;
+  getMapEntryCallApiUrl: (contractAddress: string, contractNam: string, mapName: string) => string;
 }
 
 export class StacksMainnet implements StacksNetwork {
@@ -29,6 +30,7 @@ export class StacksMainnet implements StacksNetwork {
   accountEndpoint = '/v2/accounts';
   contractAbiEndpoint = '/v2/contracts/interface';
   readOnlyFunctionCallEndpoint = '/v2/contracts/call-read';
+  mapEntryCallEndpoint = '/v2/map_entry';
   getBroadcastApiUrl = () => `${this.coreApiUrl}${this.broadcastEndpoint}`;
   getTransferFeeEstimateApiUrl = () => `${this.coreApiUrl}${this.transferFeeEstimateEndpoint}`;
   getAccountApiUrl = (address: string) =>
@@ -43,6 +45,13 @@ export class StacksMainnet implements StacksNetwork {
     `${this.coreApiUrl}${
       this.readOnlyFunctionCallEndpoint
     }/${contractAddress}/${contractName}/${encodeURIComponent(functionName)}`;
+  getMapEntryCallApiUrl = (
+    contractAddress: string,
+    contractName: string,
+    mapName: string,
+    proof: string = '0'
+  ) =>
+    `${this.coreApiUrl}${this.mapEntryCallEndpoint}/${contractAddress}/${contractName}/${mapName}?proof=${proof}`;
 }
 
 export class StacksTestnet extends StacksMainnet implements StacksNetwork {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -156,7 +156,10 @@ export async function fetchPrivate(input: RequestInfo, init?: RequestInit): Prom
   const fetchResult = await fetch(input, fetchOpts);
   return fetchResult;
 }
-
+/**
+ * Converts a clarity value to a hex encoded string with `0x` prefix
+ * @param cv
+ */
 export function cvToHex(cv: ClarityValue) {
   const serialized = serializeCV(cv);
   return `0x${serialized.toString('hex')}`;
@@ -174,6 +177,10 @@ export interface ReadOnlyFunctionResponse {
   result: string;
 }
 
+/**
+ * Converts the response of a read-only function call into its Clarity Value
+ * @param param
+ */
 export const parseReadOnlyResponse = ({ result }: ReadOnlyFunctionResponse): ClarityValue => {
   const hex = result.slice(2);
   const bufferCV = Buffer.from(hex, 'hex');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { sha256, sha512 } from 'sha.js';
 
-import { ClarityValue, serializeCV } from './clarity';
+import { ClarityType, ClarityValue, serializeCV, TupleCV } from './clarity';
 
 import RIPEMD160 from 'ripemd160-min';
 
@@ -14,6 +14,7 @@ import { c32addressDecode } from 'c32check';
 // Note: lodash is using old-style ts exports and requires this
 // @ts-expect-error
 import * as lodashCloneDeep from 'lodash/cloneDeep';
+import { noneCV, OptionalCV, optionalCVOf } from './clarity/types/optionalCV';
 
 export { randombytes as randomBytes };
 
@@ -187,6 +188,21 @@ export const parseReadOnlyResponse = ({ result }: ReadOnlyFunctionResponse): Cla
   return deserializeCV(bufferCV);
 };
 
+export interface GetMapEntryResponse {
+  data: string;
+  proof?: string;
+}
+
+export const parseGetMapEntryResponse = ({ data }: GetMapEntryResponse): OptionalCV => {
+  const hex = data.slice(2);
+  const bufferCV = Buffer.from(hex, 'hex');
+  return deserializeCV(bufferCV) as OptionalCV;
+};
+
+/**
+ *
+ * @param stacksAddress
+ */
 export const validateStacksAddress = (stacksAddress: string): boolean => {
   try {
     c32addressDecode(stacksAddress);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -180,7 +180,7 @@ export interface ReadOnlyFunctionResponse {
 
 /**
  * Converts the response of a read-only function call into its Clarity Value
- * @param param
+ * @param param0 the read-only function response
  */
 export const parseReadOnlyResponse = ({ result }: ReadOnlyFunctionResponse): ClarityValue => {
   const hex = result.slice(2);
@@ -188,11 +188,20 @@ export const parseReadOnlyResponse = ({ result }: ReadOnlyFunctionResponse): Cla
   return deserializeCV(bufferCV);
 };
 
+/**
+ * Map Entry query response object
+ * @param {string} data - a hex encoded string of the optional map entry
+ * @param {string?} proof - the MARF proof of the data
+ */
 export interface GetMapEntryResponse {
   data: string;
   proof?: string;
 }
 
+/**
+ * Converts the response of a map entry call into its Clarity Value
+ * @param param0 the map entry call response
+ */
 export const parseGetMapEntryResponse = ({ data }: GetMapEntryResponse): OptionalCV => {
   const hex = data.slice(2);
   const bufferCV = Buffer.from(hex, 'hex');


### PR DESCRIPTION
## Description

As a Blockstack developer, I would like to query the blockchain for data map entries of a contract. This is needed in the same was as read-only function calls. This pull request adds the `getMapEntry` function which uses helper methods `cvToHex` and `parseMapEntryResponse`. Both are exported as well.

For details refer to issue #126 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No, just a new feature

## Are documentation updates required?
yes
## Testing information
A new test in builder-tests.js was added that calls `getMapEntry`.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag @yknl
