### PR TITLE
feat: builder for unsigned contract call

### DIFF
--- a/src/builders.ts
+++ b/src/builders.ts
@@ -298,7 +298,7 @@ export interface SignedMultiSigTokenTransferOptions extends TokenTransferOptions
  *
  * @param  {UnsignedTokenTransferOptions | UnsignedMultiSigTokenTransferOptions} txOptions - an options object for the token transfer
  *
- * @return {StacksTransaction}
+ * @return {Promise<StacksTransaction>}
  */
 export async function makeUnsignedSTXTokenTransfer(
   txOptions: UnsignedTokenTransferOptions | UnsignedMultiSigTokenTransferOptions
@@ -611,7 +611,6 @@ export interface ContractCallOptions {
   contractName: string;
   functionName: string;
   functionArgs: ClarityValue[];
-  senderKey: string;
   fee?: BigNum;
   feeEstimateApiUrl?: string;
   nonce?: BigNum;
@@ -621,6 +620,25 @@ export interface ContractCallOptions {
   postConditions?: PostCondition[];
   validateWithAbi?: boolean | ClarityAbi;
   sponsored?: boolean;
+}
+
+export interface UnsignedContractCallOptions extends ContractCallOptions {
+  publicKey: string;
+}
+
+export interface SignedContractCallOptions extends ContractCallOptions {
+  senderKey: string;
+}
+
+export interface UnsignedMultiSigContractCallOptions extends ContractCallOptions {
+  numSignatures: number;
+  publicKeys: string[];
+}
+
+export interface SignedMultiSigContractCallOptions extends ContractCallOptions {
+  numSignatures: number;
+  publicKeys: string[];
+  signerKeys: string[];
 }
 
 /**
@@ -676,15 +694,15 @@ export async function estimateContractFunctionCall(
 }
 
 /**
- * Generates a Clarity smart contract function call transaction
+ * Generates an unsigned Clarity smart contract function call transaction
  *
- * @param  {ContractCallOptions} txOptions - an options object for the contract function call
+ * @param {UnsignedContractCallOptions | UnsignedMultiSigContractCallOptions} txOptions - an options object for the contract call
  *
- * Returns a signed Stacks smart contract function call transaction.
- *
- * @return {StacksTransaction}
+ * @returns {Promise<StacksTransaction>}
  */
-export async function makeContractCall(txOptions: ContractCallOptions): Promise<StacksTransaction> {
+export async function makeUnsignedContractCall(
+  txOptions: UnsignedContractCallOptions | UnsignedMultiSigContractCallOptions
+): Promise<StacksTransaction> {
   const defaultOptions = {
     fee: new BigNum(0),
     nonce: new BigNum(0),
@@ -718,18 +736,27 @@ export async function makeContractCall(txOptions: ContractCallOptions): Promise<
     validateContractCall(payload, abi);
   }
 
-  const addressHashMode = AddressHashMode.SerializeP2PKH;
-  const privKey = createStacksPrivateKey(options.senderKey);
-  const pubKey = getPublicKey(privKey);
-
+  let spendingCondition = null;
   let authorization = null;
 
-  const spendingCondition = createSingleSigSpendingCondition(
-    addressHashMode,
-    publicKeyToString(pubKey),
-    options.nonce,
-    options.fee
-  );
+  if ('publicKey' in options) {
+    // single-sig
+    spendingCondition = createSingleSigSpendingCondition(
+      AddressHashMode.SerializeP2PKH,
+      options.publicKey,
+      options.nonce,
+      options.fee
+    );
+  } else {
+    // multi-sig
+    spendingCondition = createMultiSigSpendingCondition(
+      AddressHashMode.SerializeP2SH,
+      options.numSignatures,
+      options.publicKeys,
+      options.nonce,
+      options.fee
+    );
+  }
 
   if (options.sponsored) {
     authorization = new SponsoredAuthorization(spendingCondition);
@@ -765,17 +792,54 @@ export async function makeContractCall(txOptions: ContractCallOptions): Promise<
       options.network.version === TransactionVersion.Mainnet
         ? AddressVersion.MainnetSingleSig
         : AddressVersion.TestnetSingleSig;
-    const senderAddress = publicKeyToAddress(addressVersion, pubKey);
+    const senderAddress = c32address(addressVersion, transaction.auth.spendingCondition!.signer);
     const txNonce = await getNonce(senderAddress, options.network);
     transaction.setNonce(txNonce);
   }
 
-  if (options.senderKey) {
+  return transaction;
+}
+
+/**
+ * Generates a Clarity smart contract function call transaction
+ *
+ * @param  {SignedContractCallOptions | SignedMultiSigContractCallOptions} txOptions - an options object for the contract function call
+ *
+ * Returns a signed Stacks smart contract function call transaction.
+ *
+ * @return {StacksTransaction}
+ */
+export async function makeContractCall(
+  txOptions: SignedContractCallOptions | SignedMultiSigContractCallOptions
+): Promise<StacksTransaction> {
+  if ('senderKey' in txOptions) {
+    const publicKey = publicKeyToString(getPublicKey(createStacksPrivateKey(txOptions.senderKey)));
+    const options = omit(txOptions, 'senderKey');
+    const transaction = await makeUnsignedContractCall({ publicKey, ...options });
+
+    const privKey = createStacksPrivateKey(txOptions.senderKey);
     const signer = new TransactionSigner(transaction);
     signer.signOrigin(privKey);
-  }
 
-  return transaction;
+    return transaction;
+  } else {
+    const options = omit(txOptions, 'signerKeys');
+    const transaction = await makeUnsignedContractCall(options);
+
+    const signer = new TransactionSigner(transaction);
+    let pubKeys = txOptions.publicKeys;
+    for (const key of txOptions.signerKeys) {
+      const pubKey = pubKeyfromPrivKey(key);
+      pubKeys = pubKeys.filter(pk => pk !== pubKey.data.toString('hex'));
+      signer.signOrigin(createStacksPrivateKey(key));
+    }
+
+    for (const key of pubKeys) {
+      signer.appendOrigin(publicKeyFromBuffer(Buffer.from(key, 'hex')));
+    }
+
+    return transaction;
+  }
 }
 
 /**

--- a/tests/src/builder-tests.ts
+++ b/tests/src/builder-tests.ts
@@ -19,6 +19,7 @@ import {
   callReadOnlyFunction,
   sponsorTransaction,
   makeSTXTokenTransfer,
+  makeUnsignedContractCall
 } from '../../src/builders';
 
 import { deserializeTransaction } from '../../src/transaction';
@@ -475,6 +476,76 @@ test('Make contract-call with post condition allow mode', async () => {
     '5e9bda394a9c5003429086b762d73746f7265096765742d76616c7565000000010200000003666f6f';
 
   expect(serialized).toBe(tx);
+});
+
+test('addSignature to an unsigned contract call transaction', async () => {
+  const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'kv-store';
+  const functionName = 'get-value';
+  const buffer = bufferCV(Buffer.from('foo'));
+  const fee = new BigNum(0);
+  const publicKey = '021ae7f08f9eaecaaa93f7c6ceac29213bae09588c15e2aded32016b259cfd9a1f';
+
+  const unsignedTx = await makeUnsignedContractCall({
+    contractAddress,
+    contractName,
+    functionName,
+    functionArgs: [buffer],
+    publicKey,
+    fee,
+    nonce: new BigNum(1),
+    network: new StacksTestnet(),
+    postConditionMode: PostConditionMode.Allow,
+  });
+
+  const nullSignature = (unsignedTx.auth.spendingCondition as any).signature.data;
+
+  expect(nullSignature).toEqual(
+    '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+  );
+
+  const sig =
+    '00e4ee626905ee9d04b786e2942a69504dcc0f35ca79b86fb0aafcd47a81fc3bf1547e302c3acf5c89d935a53df334316e6fcdc203cf6bed91288ebf974385398c';
+  const signedTx = unsignedTx.createTxWithSignature(sig);
+  expect((signedTx.auth.spendingCondition as SingleSigSpendingCondition).signature.data).toEqual(
+    sig
+  );
+  expect(unsignedTx).not.toBe(signedTx);
+});
+
+test('make a multi-sig contract call', async () => {
+  const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'kv-store';
+  const functionName = 'get-value';
+  const buffer = bufferCV(Buffer.from('foo'));
+  const fee = new BigNum(0);
+  const privKeyStrings = [
+    '6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001',
+    '2a584d899fed1d24e26b524f202763c8ab30260167429f157f1c119f550fa6af01',
+    'd5200dee706ee53ae98a03fba6cf4fdcc5084c30cfa9e1b3462dcdeaa3e0f1d201',
+  ];
+  const privKeys = privKeyStrings.map(createStacksPrivateKey);
+
+  const pubKeys = privKeyStrings.map(pubKeyfromPrivKey);
+  const pubKeyStrings = pubKeys.map(publicKeyToString);
+
+  const tx = await makeContractCall({
+    contractAddress,
+    contractName,
+    functionName,
+    functionArgs: [buffer],
+    publicKeys: pubKeyStrings,
+    numSignatures: 3,
+    signerKeys: privKeyStrings,
+    fee,
+    nonce: new BigNum(1),
+    network: new StacksTestnet(),
+    postConditionMode: PostConditionMode.Allow,
+  });
+
+  expect(tx.auth.spendingCondition!.signer).toEqual(
+    '04128cacf0764f69b1e291f62d1dcdd8f65be5ab'
+  );
 });
 
 test('Estimate token transfer fee', async () => {


### PR DESCRIPTION
fixes #125. cc @kyranjamie . I'm building this for the Stacks Wallet, so we can sign Stacking transactions with a hardware wallet.

Use the following template to create your pull request

## Description

Adds `makeUnsignedContractCall` function. This is built to be almost identical to the `makeUnsignedStacksTokenTransfer` function, which can accept one or more public keys. The actual `makeContractCall`, similarly, uses the unsigned variant to build the transaction, and then it simply signs the TX.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
