### PR TITLE
fix: switch default buffer to string encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `getMapEntry` method to query contract data maps
 - Added `cvToHex` and `parseReadOnlyResponse`, `parseMapEntryResponse`
 
+### Changed
+
+- Default buffer to string encoding is now `hex` in the `cvToString()` method
+
 ## v0.6.1
 
 - Fixed `BufferArray` class so that it does not need to rely on extending the Array native class

--- a/src/clarity/clarityValue.ts
+++ b/src/clarity/clarityValue.ts
@@ -55,7 +55,7 @@ export type ClarityValue =
   | StringAsciiCV
   | StringUtf8CV;
 
-export function cvToString(val: ClarityValue, encoding: 'tryAscii' | 'hex' = 'tryAscii'): string {
+export function cvToString(val: ClarityValue, encoding: 'tryAscii' | 'hex' = 'hex'): string {
   switch (val.type) {
     case ClarityType.BoolTrue:
       return 'true';

--- a/tests/src/clarity-tests.ts
+++ b/tests/src/clarity-tests.ts
@@ -342,7 +342,7 @@ describe('Clarity Types', () => {
         (tuple 
           (a -1) 
           (b u1) 
-          (c "test") 
+          (c 0x74657374) 
           (d true) 
           (e (some true)) 
           (f none) 


### PR DESCRIPTION
Change default buffer to string encoding from `ascii` to `hex`

fixes: https://github.com/blockstack/blockstack.js/issues/834